### PR TITLE
docs: add README, ARCHITECTURE, and ROADMAP

### DIFF
--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -7,8 +7,13 @@ set -euo pipefail
 # Usage: generate-changelog.sh <prev_tag> <current_tag>
 # Output: writes changelog entries to /tmp/changelog_entries.txt
 
-PREV_TAG="${1:?Usage: generate-changelog.sh <prev_tag> <current_tag>}"
+PREV_TAG="${1:-}"
 TAG="${2:?Usage: generate-changelog.sh <prev_tag> <current_tag>}"
+
+if [ -z "$PREV_TAG" ]; then
+  # First release — no previous tag, use full history
+  PREV_TAG=$(git rev-list --max-parents=0 HEAD | head -1)
+fi
 
 ADDED=""
 CHANGED=""

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,294 @@
+# kmp-uwb Architecture
+
+This document explains the key design decisions and internal structure of kmp-uwb. It's intended for contributors and anyone curious about how the library works under the hood.
+
+---
+
+## Overview
+
+kmp-uwb is a Kotlin Multiplatform UWB library targeting Android and iOS. The core design principle is: **shared logic in `commonMain`, platform bridges in `expect/actual`, no platform details leaking into the public API.**
+
+```
+commonMain (shared)
+├── Public API (interfaces, sealed types, value classes)
+├── expect declarations (UwbAdapter, RangingSession)
+└── Test doubles (FakeRangingSession, FakeUwbAdapter)
+
+androidMain
+├── actual UwbAdapter  → androidx.core.uwb
+└── actual RangingSession → UwbManager + RangingParameters
+
+iosMain
+├── actual UwbAdapter  → NearbyInteraction availability checks
+└── actual RangingSession → NISession + NISessionDelegate
+
+jvmMain
+├── actual UwbAdapter  → always UNSUPPORTED
+└── actual RangingSession → throws at construction
+```
+
+Consumers write against the common API. Platform code never appears in import statements.
+
+---
+
+## State Machine
+
+The ranging state machine tracks every session through 10 states with an exhaustive sealed interface hierarchy.
+
+### States
+
+```
+RangingState
+├── Idle
+│   ├── Ready              — Session can be started
+│   └── Unsupported        — Hardware not available
+├── Starting
+│   ├── Negotiating        — Exchanging session parameters with peer
+│   └── Initializing       — Platform session being created
+├── Active
+│   ├── Ranging            — Measurements flowing
+│   ├── Suspended          — Temporarily paused by system (iOS background)
+│   └── PeerLost           — Peer left range, session still alive
+└── Stopped
+    ├── ByRequest          — Local close() called
+    ├── ByPeer             — Remote peer ended session
+    ├── ByError(error)     — Session failed with details
+    └── BySystemEvent      — UWB disabled, airplane mode
+```
+
+### Transition Rules
+
+States follow a strict forward progression: `Idle → Starting → Active → Stopped`. Within `Active`, lateral transitions are allowed (`Ranging ↔ Suspended ↔ PeerLost`). Once in `Stopped`, no further transitions occur — the session is terminal.
+
+Transitions are enforced by the `check()` precondition in `start()` and the `if (_state.value !is RangingState.Stopped)` guard in `close()`. A session that stops due to error cannot be overwritten by a subsequent `close()`.
+
+### Why 10 States?
+
+Other approaches collapse this into ~3 states (Idle, Active, Stopped). This makes it impossible to distinguish:
+
+- "Session is negotiating parameters" vs "platform session is initializing"
+- "Peer is temporarily out of range" vs "session was suspended by the OS"
+- "I closed the session" vs "the peer disconnected" vs "UWB was turned off"
+
+Each state maps to a distinct UI condition a consumer needs to handle.
+
+---
+
+## Concurrency Model
+
+### The Problem
+
+Android's `UwbManager` delivers ranging results via `Flow.collect()` on the caller's coroutine. iOS's `NISessionDelegate` delivers callbacks on an Apple-managed dispatch queue. Both platforms need state mutations serialized to prevent races.
+
+### Single-Writer Architecture
+
+```
+Layer 1: Platform callbacks (OS-managed)
+    ↓  Channel.trySend / scope.launch
+Layer 2: Serialized state mutations (limitedParallelism(1))
+    ↓  StateFlow / receiveAsFlow
+Layer 3: Consumer API (caller's coroutine context)
+```
+
+**Layer 2** uses `Dispatchers.Default.limitedParallelism(1)` — a serial execution view that works on all KMP targets without `expect/actual`. At most one coroutine runs at a time per session. No locks, no mutexes.
+
+**Each session has its own serialized scope.** This is critical on iOS, where `NISessionDelegate` callbacks arrive on Apple's dispatch queue. Every delegate method wraps state mutations in `scope.launch { }` to hop back onto the serialized dispatcher.
+
+### Why Not Mutex?
+
+`limitedParallelism(1)` provides stronger guarantees: it serializes the *entire coroutine body*, not just a critical section. With `Mutex`, you can accidentally access shared state outside the lock. With a serial dispatcher, all code on the scope is automatically serialized.
+
+---
+
+## Ranging Results Pipeline
+
+### Hot Flow with Bounded Buffer
+
+```kotlin
+private val resultChannel = Channel<RangingResult>(
+    capacity = 64,
+    onBufferOverflow = BufferOverflow.DROP_OLDEST,
+)
+override val rangingResults: Flow<RangingResult> = resultChannel.receiveAsFlow()
+```
+
+UWB measurements arrive at high frequency (~5 Hz). The pipeline is designed for this:
+
+- **`Channel(64, DROP_OLDEST)`** — if a consumer falls behind, stale measurements are silently dropped. The consumer always sees the most recent data.
+- **`receiveAsFlow()`** — converts the channel to a cold-on-subscription Flow. Unlike `channelFlow`, this doesn't start a new platform session per collector.
+- **`trySend()`** — non-suspending send from platform callbacks. Never blocks the OS callback thread.
+
+### Why Not SharedFlow?
+
+`MutableSharedFlow(replay=0)` drops values when no collector is active. `MutableSharedFlow(replay=1)` replays stale data to new collectors. The channel approach gives explicit buffer control with `DROP_OLDEST` semantics — the right trade-off for real-time sensor data.
+
+### Single Session Start
+
+On Android, `scope.launch { startRangingWithPeer(peer) }` runs once when `start()` is called. The launched coroutine collects from `sessionScope.prepareSession()` and feeds results into the channel. This avoids the pitfall where each `collect()` call on `rangingResults` would create a new platform session.
+
+---
+
+## Error Model
+
+Errors use **sealed interfaces** for composability. A single error can implement multiple facets:
+
+```
+UwbError
+├── SessionError
+│   ├── SessionLost(message, cause?)
+│   └── SessionRejected(message)
+├── RangingError
+│   ├── PeerUnreachable(message)
+│   └── ChipsetError(message)  — also implements HardwareError
+├── HardwareError
+│   ├── ChipsetError(message)
+│   ├── UnsupportedFeature(message)
+│   └── UwbUnavailable(message)
+└── SecurityError
+    └── StsVerificationFailed(message)
+```
+
+`ChipsetError` is both a `RangingError` and a `HardwareError`. Consumers can `when`-branch on whichever facet they care about:
+
+```kotlin
+when (error) {
+    is SecurityError -> promptReAuth()
+    is HardwareError -> showHardwareUnavailable()
+    is SessionError -> showRetryDialog()
+}
+```
+
+---
+
+## Value Classes
+
+### Distance
+
+`Distance` is a `@JvmInline value class` that bit-packs a `Double` into a `Long`:
+
+```kotlin
+@JvmInline
+public value class Distance private constructor(private val packed: Long) : Comparable<Distance> {
+    public val meters: Double get() = Double.fromBits(packed)
+}
+```
+
+Construction validates non-negative values. Extension properties (`2.5.meters`, `150.centimeters`) provide ergonomic creation. `toString()` rounds to two decimal places.
+
+### Angle
+
+`Angle` wraps a `Double` in degrees, with a `radians` computed property. Factory methods: `Angle.degrees()`, `Angle.radians()`. Extension properties: `15.0.degrees`.
+
+### Why Value Classes?
+
+Zero-allocation on JVM. Type safety — you can't accidentally pass a distance where an angle is expected. Unit conversion is built into the type (`angle.radians`, `distance.meters`).
+
+---
+
+## Peer Identity
+
+### PeerAddress
+
+`PeerAddress` wraps a `ByteArray` with content-based equality:
+
+```kotlin
+public class PeerAddress(bytes: ByteArray) {
+    private val bytes: ByteArray = bytes.copyOf() // defensive copy on construction
+    public fun toByteArray(): ByteArray = bytes.copyOf() // defensive copy on access
+}
+```
+
+This was initially a `@JvmInline value class`, but `ByteArray` uses referential equality by default — two `PeerAddress` instances with identical bytes would not be equal. Converting to a regular class with `contentEquals`/`contentHashCode` fixes this.
+
+### iOS Discovery Token Serialization
+
+On iOS, `NINearbyObject` identifies peers by `NIDiscoveryToken` (an opaque ObjC object). The library serializes tokens to stable byte representations via `NSKeyedArchiver`:
+
+```
+NIDiscoveryToken → NSKeyedArchiver.archivedDataWithRootObject() → NSData → memcpy → ByteArray → PeerAddress
+```
+
+This ensures consistent peer identity across delegate callbacks throughout a session's lifetime.
+
+---
+
+## Platform Bridges
+
+### Android
+
+| Common | Android |
+|--------|---------|
+| `UwbAdapter` | `PackageManager.FEATURE_UWB` check + `UwbManager` capabilities |
+| `RangingSession` | `UwbManager.controllerSessionScope()` / `controleeSessionScope()` |
+| `RangingResult` | `androidx.core.uwb.RangingResult.RangingResultPosition` / `RangingResultPeerDisconnected` |
+| Auto-init | `AndroidX Startup` — `KmpUwbInitializer` captures `Context` at app launch |
+
+The Android implementation uses `RangingParameters` with DS-TWR (Double-Sided Two-Way Ranging) and automatic update rate.
+
+### iOS
+
+| Common | iOS |
+|--------|-----|
+| `UwbAdapter` | `NISession.deviceCapabilities` availability check |
+| `RangingSession` | `NISession` with `NISessionDelegate` |
+| `RangingResult` | `NINearbyObject.distance` + `direction` (simd_float3 → `Vector128`) |
+| Direction parsing | `Vector128.getFloatAt(0/1/2)` for x/y/z → `atan2` for azimuth/elevation |
+
+The `NISessionDelegate` implements multiple `session(_:...)` overloads for the `NISessionDelegateProtocol`. Kotlin/Native 2.3.20 handles the ObjC selector disambiguation automatically — no `@Suppress` annotations needed.
+
+### JVM
+
+The JVM target provides stub implementations that report `UwbAdapterState.UNSUPPORTED` and throw `UnsupportedOperationException` on session creation. This allows common tests to compile and run on host without requiring UWB hardware.
+
+---
+
+## Testing Infrastructure
+
+### FakeRangingSession
+
+A fully controllable test double implementing `RangingSession`:
+
+```kotlin
+val fake = FakeRangingSession(config)
+fake.start(peer)
+
+// Inject measurements
+fake.emitResult(RangingResult.Position(peer, measurement))
+
+// Simulate lifecycle events
+fake.simulatePeerLost(peer)
+fake.simulateError(SessionLost(message = "test"))
+fake.simulateSuspend()
+fake.simulateResume()
+```
+
+Uses `Channel.UNLIMITED` (not `Channel.BUFFERED`) so test emissions never block, regardless of consumption timing. Tracks active peers via a `MutableSet` exposed as an immutable snapshot.
+
+### FakeUwbAdapter
+
+Controls adapter state and capabilities for tests:
+
+```kotlin
+val fake = FakeUwbAdapter()
+fake.simulateDisabled()  // state → OFF
+fake.simulateEnabled()   // state → ON
+fake.simulateUnsupported() // state → UNSUPPORTED
+```
+
+---
+
+## Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Separate repo from kmp-ble | Different hardware, different APIs, different release cadence. No compile-time coupling |
+| `expect/actual` factory functions | `UwbAdapter()` and `RangingSession(config)` look like constructors but dispatch to platform implementations. No DI framework required |
+| Channel over SharedFlow | Explicit buffer control with `DROP_OLDEST` for real-time sensor data |
+| Content-based PeerAddress | `ByteArray` referential equality is a footgun. Regular class with `contentEquals` prevents subtle bugs |
+| Single-writer concurrency | `limitedParallelism(1)` serializes all state mutations per session without locks |
+| JVM stubs | Lets common tests run on host. Desktop UWB is not a current target |
+| AndroidX Startup auto-init | Zero-config for consumers. Opt-out available via manifest merge rules |
+
+---
+
+*Current as of v0.1.0*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,195 @@
+# kmp-uwb
+
+[![CI](https://github.com/gary-quinn/kmp-uwb/actions/workflows/ci.yml/badge.svg)](https://github.com/gary-quinn/kmp-uwb/actions/workflows/ci.yml)
+[![Publish](https://github.com/gary-quinn/kmp-uwb/actions/workflows/publish.yml/badge.svg)](https://github.com/gary-quinn/kmp-uwb/actions/workflows/publish.yml)
+[![Maven Central](https://img.shields.io/maven-central/v/com.atruedev/kmp-uwb)](https://central.sonatype.com/artifact/com.atruedev/kmp-uwb)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.20-purple.svg)](https://kotlinlang.org)
+
+Kotlin Multiplatform UWB (Ultra-Wideband) library for Android and iOS.
+
+Part of the **kmp** library family alongside [kmp-ble](https://github.com/gary-quinn/kmp-ble). Use kmp-uwb for centimetre-accurate spatial awareness — device ranging, angle-of-arrival, and peer tracking — with the same shared-code-first philosophy.
+
+## Features
+
+| Capability | Description |
+|------------|-------------|
+| **Ranging Sessions** | Start peer-to-peer TWR (Two-Way Ranging) sessions with real-time distance and angle measurements |
+| **Angle of Arrival** | Azimuth and elevation from the device's UWB antenna, when hardware supports it |
+| **Adapter State** | Observe hardware availability and query device capabilities |
+| **Session Lifecycle** | 10-state state machine with exhaustive transitions — no ambiguous states |
+| **Composable Errors** | Sealed interface hierarchy — errors can implement multiple facets (`SessionError + HardwareError`) |
+| **Test Without Hardware** | `FakeRangingSession` and `FakeUwbAdapter` for full UWB simulation in unit tests |
+| **FiRa Compliant** | Static, Dynamic, and Provisioned STS security modes. Controller/Controlee roles |
+
+## Setup
+
+### Android / KMP (Gradle)
+
+```kotlin
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation("com.atruedev:kmp-uwb:0.1.0")
+        }
+    }
+}
+```
+
+The library auto-initializes on Android via [AndroidX Startup](https://developer.android.com/topic/libraries/app-startup) — no manual `init()` call needed. If your app disables auto-initialization, call `KmpUwb.init(context)` manually.
+
+### iOS (Swift Package Manager)
+
+In Xcode: **File > Add Package Dependencies** and enter:
+
+```
+https://github.com/gary-quinn/kmp-uwb
+```
+
+Select the version and add `KmpUwb` to your target.
+
+```swift
+import KmpUwb
+```
+
+> **Note:** UWB requires a U1 or U2 chip. On iOS, the `NearbyInteraction` framework is only available on iPhone 11+ and Apple Watch Series 6+.
+
+## Usage
+
+### Check UWB availability
+
+```kotlin
+val adapter = UwbAdapter()
+
+adapter.state.collect { state ->
+    when (state) {
+        UwbAdapterState.ON -> println("UWB ready")
+        UwbAdapterState.OFF -> println("UWB disabled")
+        UwbAdapterState.UNSUPPORTED -> println("No UWB hardware")
+    }
+}
+```
+
+### Query capabilities
+
+```kotlin
+val capabilities = adapter.capabilities()
+println("Roles: ${capabilities.supportedRoles}")
+println("AoA: ${capabilities.angleOfArrivalSupported}")
+println("Channels: ${capabilities.supportedChannels}")
+println("Background: ${capabilities.backgroundRangingSupported}")
+```
+
+### Configure a session
+
+```kotlin
+val config = rangingConfig {
+    role = RangingRole.CONTROLLER
+    channel = 9
+    stsMode = StsMode.DYNAMIC
+    angleOfArrival = true
+    rangingInterval = 200.milliseconds
+}
+```
+
+### Start ranging
+
+```kotlin
+val session = RangingSession(config)
+val peer = Peer(address = PeerAddress(peerAddressBytes))
+
+session.start(peer)
+
+// Observe state
+session.state.collect { state ->
+    when (state) {
+        is RangingState.Active.Ranging -> println("Ranging active")
+        is RangingState.Active.Suspended -> println("Session suspended by system")
+        is RangingState.Active.PeerLost -> println("Peer out of range")
+        is RangingState.Stopped.ByError -> println("Error: ${state.error}")
+        else -> {}
+    }
+}
+```
+
+### Collect measurements
+
+```kotlin
+session.rangingResults.collect { result ->
+    when (result) {
+        is RangingResult.Position -> {
+            println("Distance: ${result.measurement.distance}")       // e.g. 1.23 m
+            println("Azimuth: ${result.measurement.azimuth}")         // horizontal angle
+            println("Elevation: ${result.measurement.elevation}")     // vertical angle
+        }
+        is RangingResult.PeerLost -> println("Lost: ${result.peer}")
+        is RangingResult.PeerRecovered -> println("Recovered: ${result.peer}")
+    }
+}
+
+// Clean up
+session.close()
+```
+
+### Test without hardware
+
+```kotlin
+val fakeSession = FakeRangingSession(
+    config = rangingConfig { role = RangingRole.CONTROLLER },
+)
+val peer = Peer(address = PeerAddress(byteArrayOf(0x01, 0x02)))
+
+fakeSession.start(peer)
+
+// Inject a measurement
+fakeSession.emitResult(
+    RangingResult.Position(
+        peer = peer,
+        measurement = RangingMeasurement(
+            distance = Distance.meters(2.5),
+            azimuth = Angle.degrees(15.0),
+            elevation = Angle.degrees(-5.0),
+        ),
+    )
+)
+
+// Simulate error
+fakeSession.simulateError(SessionLost(message = "connection dropped"))
+```
+
+## Relationship with kmp-ble
+
+kmp-uwb and kmp-ble are **independent libraries** with no compile-time dependency. They share the same design philosophy:
+
+| | kmp-ble | kmp-uwb |
+|---|---|---|
+| **Technology** | Bluetooth Low Energy | Ultra-Wideband |
+| **Range** | ~100 m | ~10 m (centimetre-accurate) |
+| **Use cases** | Data transfer, device control, firmware updates | Spatial awareness, precision ranging, indoor positioning |
+| **State model** | 14-state connection FSM | 10-state ranging FSM |
+| **Error model** | Composable sealed interfaces | Composable sealed interfaces |
+| **Testing** | FakePeripheral, FakeScanner | FakeRangingSession, FakeUwbAdapter |
+
+A typical spatial app might use kmp-ble for device discovery and data exchange, then kmp-uwb for precise positioning — but neither requires the other.
+
+## Architecture
+
+- **State machine:** 10 states with sealed interface hierarchy — exhaustive `when` branches
+- **Per-session concurrency:** `limitedParallelism(1)` serialization, no locks
+- **Hot Flow ranging:** `Channel(64, DROP_OLDEST)` — consumers always see the latest measurement
+- **Value classes:** `Distance` and `Angle` are zero-allocation wrappers with unit conversion
+- **Composable errors:** Sealed interfaces — `SessionError`, `RangingError`, `HardwareError`, `SecurityError`
+- **Defensive copies:** `PeerAddress` copies on construction and access — no aliasing bugs
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for full design documentation.
+
+## Requirements
+
+- Kotlin 2.3.0+
+- Android minSdk 33
+- iOS 15+ (U1/U2 chip required for UWB)
+- kotlinx-coroutines 1.10+
+
+## License
+
+[Apache 2.0](LICENSE) — Copyright (C) 2026 Gary Quinn

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,116 @@
+# kmp-uwb Roadmap
+
+> Centimetre-accurate spatial awareness for Kotlin Multiplatform — Android & iOS.
+
+This document tracks what's shipped, what's next, and where kmp-uwb is headed. Updated as milestones are reached.
+
+**Platforms:** Android (API 33+), iOS (15+)
+
+> **Note:** All 0.x releases may contain breaking API changes. Pin to a specific minor version for stability. See the [CHANGELOG](CHANGELOG.md) for migration notes between versions.
+
+---
+
+## Shipped
+
+### v0.1.x — Foundation
+
+Everything needed to build production UWB ranging apps on Android and iOS from shared Kotlin code.
+
+| Feature | Version | Details |
+|---------|---------|---------|
+| **Ranging Sessions** | v0.1.0 | Peer-to-peer TWR (Two-Way Ranging) via `RangingSession` interface. Controller and Controlee roles |
+| **Distance & Angle of Arrival** | v0.1.0 | `Distance` (meters/cm), `Angle` (degrees/radians) value classes with unit conversion |
+| **10-State State Machine** | v0.1.0 | Exhaustive sealed interface FSM — Idle, Starting, Active, Stopped with sub-states |
+| **Composable Error Hierarchy** | v0.1.0 | Sealed interfaces — `SessionError`, `RangingError`, `HardwareError`, `SecurityError`. Errors can implement multiple facets |
+| **Adapter & Capabilities** | v0.1.0 | `UwbAdapter` with state observation and hardware capability queries (roles, AoA, channels, background) |
+| **Session Configuration** | v0.1.0 | `RangingConfig` DSL builder — role, channel, STS mode (Static/Dynamic/Provisioned), AoA, ranging interval |
+| **Testing Infrastructure** | v0.1.0 | `FakeRangingSession`, `FakeUwbAdapter` — full UWB simulation for unit tests, no hardware required |
+| **Android Auto-Init** | v0.1.0 | AndroidX Startup — zero configuration for consumers |
+| **Distribution** | v0.1.0 | Maven Central (`com.atruedev:kmp-uwb`) + Swift Package Manager (XCFramework) |
+| **CI/CD Pipeline** | v0.1.0 | GitHub Actions — ktlint, Android build/test, iOS build/test, Dokka docs, Maven Central publish, GitHub Release |
+
+### Known Limitations
+
+- Desktop (JVM), Web, and other platforms are not yet supported
+- iOS requires U1/U2 chip (iPhone 11+, Apple Watch Series 6+)
+- Android requires `FEATURE_UWB` system feature and `androidx.core.uwb` alpha API
+- Background ranging behaviour varies by platform
+
+---
+
+## Planned
+
+### v0.2 — Multi-Peer & Session Management
+
+**Theme:** Real-world ranging scenarios with multiple devices.
+
+| Feature | Notes |
+|---------|-------|
+| **Multi-peer ranging** | Range to multiple peers simultaneously within a single session |
+| **Session recovery** | Auto-resume after system suspension (iOS background) |
+| **Peer discovery** | OOB (Out-of-Band) peer exchange helpers — integrate with kmp-ble or NFC for session bootstrapping |
+| **Session events Flow** | Dedicated event stream for session-level events (peer joined, peer left, suspension, resume) |
+| **Ranging filters** | Distance smoothing, outlier rejection, moving average |
+
+### v0.3 — Spatial Awareness
+
+**Theme:** Beyond distance — direction, zones, and spatial context.
+
+| Feature | Notes |
+|---------|-------|
+| **3D positioning** | Combine distance + azimuth + elevation into position coordinates |
+| **Proximity zones** | Configurable distance zones (immediate/near/far) with hysteresis |
+| **Heading estimation** | Device-relative heading from AoA data |
+| **Accuracy metrics** | Confidence intervals and NLOS (Non-Line-of-Sight) detection |
+
+### v1.0 — Stability Guarantee
+
+**Theme:** API stability commitment backed by production usage.
+
+**Criteria:**
+
+API stability:
+- Core module API (`UwbAdapter`, `RangingSession`, `RangingConfig`) unchanged for 2+ minor releases
+- Deprecation cycle enforced: deprecated APIs survive at least 1 minor release before removal
+- All public APIs have KDoc documentation
+
+Quality:
+- Zero known critical bugs at release time
+- Test coverage for all public API entry points
+- CI green on both Android and iOS targets
+
+Distribution:
+- Semantic versioning strictly followed from v1.0 onward
+- CHANGELOG.md covers every release
+
+---
+
+## Future Considerations (v1.x+)
+
+Features we're tracking but not actively working on. Community interest and use cases will determine priority.
+
+**Inclusion here does not imply commitment.** These items may be reprioritized, redesigned, or dropped based on real-world demand.
+
+| Feature | Notes |
+|---------|-------|
+| FiRa 2.0 features | Data transfer over UWB, enhanced security modes |
+| Secure ranging | End-to-end session key management with STS provisioning |
+| Indoor positioning | Map-based positioning using multiple anchors |
+| UWB + BLE fusion | Combined kmp-ble + kmp-uwb session management for discovery → ranging workflows |
+| Android CCC Digital Key | Car Connectivity Consortium profile support |
+| Geofencing | UWB-based precision geofences (sub-meter accuracy) |
+| Record-replay testing | Record real UWB sessions and replay for offline testing |
+| Additional FiRa profiles | Point-to-multipoint, device-to-infrastructure |
+| wasm / JS target | If Web UWB APIs emerge from standards bodies |
+
+---
+
+## How to Influence This Roadmap
+
+- **Feature requests:** [Open an issue](https://github.com/gary-quinn/kmp-uwb/issues) describing your use case
+- **Bug reports:** Include platform, device model, and minimal reproduction
+- **Contributions:** PRs welcome — see the issue tracker for "good first issue" labels
+
+---
+
+*Current as of v0.1.0*


### PR DESCRIPTION
## Summary

- **README.md** — project overview, badges, setup (Gradle + SPM), usage examples (adapter, config, ranging, testing), kmp-ble relationship table, architecture summary, requirements
- **ARCHITECTURE.md** — 10-state FSM, concurrency model (limitedParallelism(1)), ranging pipeline (Channel + DROP_OLDEST), error model (composable sealed interfaces), value classes, peer identity (PeerAddress + iOS discovery token serialization), platform bridges, testing infrastructure, design decision rationale table
- **ROADMAP.md** — shipped features (v0.1.x), planned milestones (v0.2 multi-peer, v0.3 spatial awareness, v1.0 stability), future considerations, known limitations

Also fixes `generate-changelog.sh` to handle the first release where no previous tag exists — falls back to full history from the initial commit instead of erroring on empty `prev_tag`.

## Test plan

- [x] CI passes (ktlint, Android build, iOS build, Dokka)
- [x] Docs render correctly on GitHub