### PR TITLE
feat(connector): add kmp-uwb-connector module with BLE OOB exchange

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ androidx-core-uwb = { module = "androidx.core.uwb:uwb", version.ref = "androidx-
 androidx-core-uwb-rxjava3 = { module = "androidx.core.uwb:uwb-rxjava3", version.ref = "androidx-core-uwb" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.2.0" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+kmp-ble = { module = "com.atruedev:kmp-ble", version = "v0.3.7" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivityCompose" }
 
 [plugins]

--- a/kmp-uwb-connector/build.gradle.kts
+++ b/kmp-uwb-connector/build.gradle.kts
@@ -1,0 +1,49 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.ktlint)
+}
+
+group = "com.atruedev"
+version = providers.environmentVariable("VERSION").getOrElse("0.0.0-local")
+
+kotlin {
+    explicitApi()
+
+    android {
+        namespace = "com.atruedev.kmpuwb.connector.ble"
+        compileSdk =
+            libs.versions.androidCompileSdk
+                .get()
+                .toInt()
+        minSdk =
+            libs.versions.androidMinSdk
+                .get()
+                .toInt()
+    }
+
+    listOf(
+        iosArm64(),
+        iosSimulatorArm64(),
+        iosX64(),
+    ).forEach { target ->
+        target.binaries.framework {
+            baseName = "KmpUwbConnector"
+            isStatic = true
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            api(project(":"))
+            api(libs.kmp.ble)
+            implementation(libs.kotlinx.coroutines.core)
+        }
+    }
+}
+
+mavenPublishing {
+    coordinates("com.atruedev", "kmp-uwb-connector", version.toString())
+}

--- a/kmp-uwb-connector/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ble/BleConnector.kt
+++ b/kmp-uwb-connector/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ble/BleConnector.kt
@@ -1,0 +1,244 @@
+package com.atruedev.kmpuwb.connector.ble
+
+import com.atruedev.kmpble.BleData
+import com.atruedev.kmpble.error.GattStatus
+import com.atruedev.kmpble.gatt.WriteType
+import com.atruedev.kmpble.peripheral.Peripheral
+import com.atruedev.kmpble.peripheral.toPeripheral
+import com.atruedev.kmpble.scanner.Scanner
+import com.atruedev.kmpble.server.AdvertiseConfig
+import com.atruedev.kmpble.server.Advertiser
+import com.atruedev.kmpble.server.GattServer
+import com.atruedev.kmpuwb.connector.ConnectorException
+import com.atruedev.kmpuwb.connector.ExchangeTimedOut
+import com.atruedev.kmpuwb.connector.InvalidRemoteParams
+import com.atruedev.kmpuwb.connector.PeerConnector
+import com.atruedev.kmpuwb.connector.TransportFailure
+import com.atruedev.kmpuwb.session.SessionParams
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+import kotlin.uuid.ExperimentalUuidApi
+
+/**
+ * [PeerConnector] implementation using BLE for automatic OOB parameter exchange.
+ *
+ * ```kotlin
+ * // Controller — scans for a controlee, connects, exchanges params
+ * val scanner = Scanner { filters { match { serviceUuid(UwbOobService.SERVICE_UUID) } } }
+ * val connector = BleConnector.controller(scanner)
+ * val session = adapter.startWithConnector(config, connector)
+ *
+ * // Controlee — advertises, waits for controller to connect and exchange
+ * val connector = BleConnector.controlee()
+ * val session = adapter.startWithConnector(config, connector)
+ * ```
+ */
+public object BleConnector {
+    public fun controller(
+        scanner: Scanner,
+        config: BleConnectorConfig = BleConnectorConfig(),
+    ): PeerConnector = ControllerConnector(scanner, config)
+
+    public fun controlee(config: BleConnectorConfig = BleConnectorConfig()): PeerConnector = ControleeConnector(config)
+}
+
+@OptIn(ExperimentalUuidApi::class)
+private class ControllerConnector(
+    private val scanner: Scanner,
+    private val config: BleConnectorConfig,
+) : PeerConnector {
+    override suspend fun exchange(localParams: SessionParams): SessionParams {
+        val peripheral = scanForPeer()
+        try {
+            return exchangeWithPeer(peripheral, localParams)
+        } finally {
+            safeDisconnect(peripheral)
+        }
+    }
+
+    private suspend fun scanForPeer(): Peripheral {
+        try {
+            val advertisement =
+                withTimeout(config.scanTimeout) {
+                    scanner.advertisements
+                        .first { it.isConnectable }
+                }
+            return advertisement.toPeripheral()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+            throw ConnectorException(
+                ExchangeTimedOut("No UWB peer found within ${config.scanTimeout}"),
+            )
+        } catch (e: Exception) {
+            throw ConnectorException(
+                TransportFailure("BLE scan failed: ${e.message}", cause = e),
+            )
+        }
+    }
+
+    private suspend fun exchangeWithPeer(
+        peripheral: Peripheral,
+        localParams: SessionParams,
+    ): SessionParams {
+        try {
+            peripheral.connect(config.connectionOptions)
+
+            val controllerChar =
+                peripheral.findCharacteristic(
+                    UwbOobService.SERVICE_UUID,
+                    UwbOobService.CONTROLLER_PARAMS_UUID,
+                ) ?: throw ConnectorException(
+                    TransportFailure("Controller params characteristic not found"),
+                )
+
+            val controleeChar =
+                peripheral.findCharacteristic(
+                    UwbOobService.SERVICE_UUID,
+                    UwbOobService.CONTROLEE_PARAMS_UUID,
+                ) ?: throw ConnectorException(
+                    TransportFailure("Controlee params characteristic not found"),
+                )
+
+            val remoteBytes =
+                withTimeout(config.exchangeTimeout) {
+                    val observation = peripheral.observeValues(controleeChar)
+
+                    peripheral.write(
+                        controllerChar,
+                        localParams.toByteArray(),
+                        WriteType.WithResponse,
+                    )
+
+                    observation.first()
+                }
+
+            if (remoteBytes.isEmpty()) {
+                throw ConnectorException(
+                    InvalidRemoteParams("Received empty params from controlee"),
+                )
+            }
+
+            return SessionParams(remoteBytes)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: ConnectorException) {
+            throw e
+        } catch (e: Exception) {
+            throw ConnectorException(
+                TransportFailure("BLE exchange failed: ${e.message}", cause = e),
+            )
+        }
+    }
+
+    private fun safeDisconnect(peripheral: Peripheral) {
+        try {
+            peripheral.close()
+        } catch (_: Exception) {
+            // cleanup errors must not mask the original
+        }
+    }
+}
+
+@OptIn(ExperimentalUuidApi::class)
+private class ControleeConnector(
+    private val config: BleConnectorConfig,
+) : PeerConnector {
+    override suspend fun exchange(localParams: SessionParams): SessionParams {
+        val remoteParamsDeferred = CompletableDeferred<ByteArray>()
+        val connectedDevice = CompletableDeferred<com.atruedev.kmpble.Identifier>()
+        val localBytes = localParams.toByteArray()
+
+        val server =
+            GattServer {
+                service(UwbOobService.SERVICE_UUID) {
+                    characteristic(UwbOobService.CONTROLLER_PARAMS_UUID) {
+                        properties {
+                            write = true
+                        }
+                        permissions {
+                            write = true
+                        }
+                        onWrite { device, data, _ ->
+                            connectedDevice.complete(device)
+                            remoteParamsDeferred.complete(data.toByteArray())
+                            GattStatus.Success
+                        }
+                    }
+                    characteristic(UwbOobService.CONTROLEE_PARAMS_UUID) {
+                        properties {
+                            read = true
+                            notify = true
+                        }
+                        permissions {
+                            read = true
+                        }
+                        onRead { _ ->
+                            BleData(localBytes)
+                        }
+                    }
+                }
+            }
+
+        val advertiser = Advertiser()
+
+        try {
+            server.open()
+
+            advertiser.startAdvertising(
+                AdvertiseConfig(
+                    serviceUuids = listOf(UwbOobService.SERVICE_UUID),
+                    connectable = true,
+                ),
+            )
+
+            val remoteBytes =
+                withTimeout(config.scanTimeout + config.exchangeTimeout) {
+                    val bytes = remoteParamsDeferred.await()
+                    val device = connectedDevice.await()
+
+                    server.notify(
+                        UwbOobService.CONTROLEE_PARAMS_UUID,
+                        device,
+                        BleData(localBytes),
+                    )
+
+                    bytes
+                }
+
+            if (remoteBytes.isEmpty()) {
+                throw ConnectorException(
+                    InvalidRemoteParams("Received empty params from controller"),
+                )
+            }
+
+            return SessionParams(remoteBytes)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: ConnectorException) {
+            throw e
+        } catch (e: Exception) {
+            throw ConnectorException(
+                TransportFailure("BLE controlee exchange failed: ${e.message}", cause = e),
+            )
+        } finally {
+            try {
+                advertiser.stopAdvertising()
+            } catch (_: Exception) {
+                // cleanup
+            }
+            try {
+                advertiser.close()
+            } catch (_: Exception) {
+                // cleanup
+            }
+            try {
+                server.close()
+            } catch (_: Exception) {
+                // cleanup
+            }
+        }
+    }
+}

--- a/kmp-uwb-connector/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ble/BleConnectorConfig.kt
+++ b/kmp-uwb-connector/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ble/BleConnectorConfig.kt
@@ -1,0 +1,13 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.atruedev.kmpuwb.connector.ble
+
+import com.atruedev.kmpble.connection.ConnectionOptions
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+public data class BleConnectorConfig(
+    val scanTimeout: Duration = 10.seconds,
+    val exchangeTimeout: Duration = 5.seconds,
+    val connectionOptions: ConnectionOptions = ConnectionOptions(timeout = 10.seconds),
+)

--- a/kmp-uwb-connector/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ble/UwbOobService.kt
+++ b/kmp-uwb-connector/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ble/UwbOobService.kt
@@ -1,0 +1,23 @@
+package com.atruedev.kmpuwb.connector.ble
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * BLE GATT service definition for UWB out-of-band parameter exchange.
+ *
+ * The controller writes its [SessionParams] to [CONTROLLER_PARAMS_UUID].
+ * The controlee exposes its [SessionParams] on [CONTROLEE_PARAMS_UUID]
+ * via read + notify.
+ */
+@OptIn(ExperimentalUuidApi::class)
+public object UwbOobService {
+    public val SERVICE_UUID: Uuid =
+        Uuid.parse("bd248b8e-2550-475b-94dd-54531845b2f1")
+
+    public val CONTROLLER_PARAMS_UUID: Uuid =
+        Uuid.parse("3591a788-b42f-46cc-a4b3-a52cc0587ed4")
+
+    public val CONTROLEE_PARAMS_UUID: Uuid =
+        Uuid.parse("6d115a7d-5042-4e84-9f3d-9b833f3862c1")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,5 +15,6 @@ dependencyResolutionManagement {
 
 rootProject.name = "kmp-uwb"
 
+include(":kmp-uwb-connector")
 include(":sample")
 include(":sample-android")


### PR DESCRIPTION
## Summary

New `kmp-uwb-connector` module implementing `PeerConnector` via kmp-ble for automatic BLE-based session parameter exchange.

### Architecture

- `BleConnector.controller(scanner)` — BLE central role: scan → connect → write local params → subscribe for remote params → return
- `BleConnector.controlee()` — BLE peripheral role: GATT server + advertiser → wait for controller write → notify with local params → return
- `UwbOobService` — custom 128-bit UUID constants for service and characteristics
- `BleConnectorConfig` — scan timeout, exchange timeout, connection options

### GATT protocol

```
Service: UWB_OOB_SERVICE
├── CONTROLLER_PARAMS (write)        — controller writes its SessionParams
└── CONTROLEE_PARAMS  (read, notify) — controlee's SessionParams
```

### Dependencies

- `api(project(":"))` — kmp-uwb core
- `api("com.atruedev:kmp-ble:v0.3.7")` — published artifact

### Usage

```kotlin
// Controller
val scanner = Scanner { filters { match { serviceUuid(UwbOobService.SERVICE_UUID) } } }
val session = adapter.startWithConnector(config, BleConnector.controller(scanner))

// Controlee
val session = adapter.startWithConnector(config, BleConnector.controlee())
```

## Test plan

- [x] `kmp-uwb-connector:compileAndroidMain` passes
- [x] `kmp-uwb-connector:compileKotlinIosSimulatorArm64` passes
- [x] `ktlintCheck` passes
- [x] `testAndroidHostTest` — all existing tests pass
- [ ] CI green