### PR TITLE
test: add Android instrumented and host tests for platform bridge code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,16 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: AVD cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-api33-${{ runner.os }}
+
       - name: Instrumented tests (emulator)
-        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2.33.0
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:
           api-level: 33
           arch: x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,40 @@ jobs:
           name: android-test-results
           path: build/reports/tests/
 
+  android-instrumented:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: zulu
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Instrumented tests (emulator)
+        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2.33.0
+        with:
+          api-level: 33
+          arch: x86_64
+          target: google_apis
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+          script: ./gradlew connectedAndroidDeviceTest
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: android-instrumented-test-results
+          path: build/reports/tests/
+
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/HARDWARE_TEST_PLAN.md
+++ b/HARDWARE_TEST_PLAN.md
@@ -1,0 +1,146 @@
+# Hardware Test Plan
+
+Manual test procedures for UWB hardware. Run before every major release.
+
+CI covers all logic that doesn't require UWB hardware. This document covers everything that does.
+
+---
+
+## Equipment
+
+### Android
+- 2 devices with UWB (e.g., Pixel 7 Pro, Samsung Galaxy S24)
+- Both running API 33+
+- Sample app (`sample-android`) installed on both
+
+### iOS
+- 2 iPhones with U1 or U2 chip (iPhone 11+)
+- Running iOS 15+
+- Sample app (`iosApp`) installed on both
+
+---
+
+## Android Test Matrix
+
+### A1. Adapter State (single device)
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | `UwbAdapter().state.value` | `UwbAdapterState.ON` |
+| 2 | Toggle UWB off in Settings, recreate adapter | `UwbAdapterState.OFF` |
+| 3 | Toggle UWB back on, recreate adapter | `UwbAdapterState.ON` |
+
+### A2. Capabilities (single device)
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | `adapter.capabilities()` | `supportedChannels` non-empty (typically {5, 9}) |
+| 2 | Check `angleOfArrivalSupported` | `true` on devices with AoA |
+| 3 | Check `supportedRoles` | Contains both CONTROLLER and CONTROLEE |
+
+### A3. Session Preparation (single device)
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | `prepareSession(CONTROLLER)` | Returns `PreparedSession` with non-empty `localParams` |
+| 2 | `prepareSession(CONTROLEE)` | Returns `PreparedSession` with non-empty `localParams` |
+| 3 | Decode `localParams` via `SessionParamsCodec` | Valid address, channel > 0 |
+| 4 | Call `startRanging` twice | Second call throws `IllegalStateException` |
+| 5 | Call `close()` then `startRanging` | Throws `IllegalStateException` |
+
+### A4. Full Ranging (two devices)
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | Device A: `prepareSession(CONTROLLER)` | Gets `localParams` |
+| 2 | Device B: `prepareSession(CONTROLEE)` | Gets `localParams` |
+| 3 | Exchange params over BLE (or manually) | Both devices have remote params |
+| 4 | Both: `startRanging(remoteParams)` | State transitions: Negotiating → Initializing → Ranging |
+| 5 | Hold devices ~1m apart | `RangingResult.Position` with `distance ~1.0m` (±0.3m) |
+| 6 | Verify azimuth present | Non-null on AoA-capable devices |
+| 7 | Move to ~3m | Distance updates to ~3.0m |
+
+### A5. Session Lifecycle (two devices)
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | Active session, call `close()` on controller | State → `Stopped.ByRequest` |
+| 2 | Active session, move device B out of range (~15m+) | `RangingResult.PeerLost`, state → `Active.PeerLost` |
+| 3 | Bring device B back in range | `RangingResult.PeerRecovered`, state → `Active.Ranging` |
+| 4 | Active session, kill app on device B | State → `Stopped.ByError` (eventually) |
+| 5 | Active session, toggle UWB off on device A | State → `Stopped.BySystemEvent` or `Stopped.ByError` |
+
+---
+
+## iOS Test Matrix
+
+### I1. Adapter State (single device)
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | `UwbAdapter().state.value` | `UwbAdapterState.ON` |
+| 2 | On device without U1/U2 (e.g., iPhone SE) | `UwbAdapterState.UNSUPPORTED` |
+
+### I2. Capabilities (single device)
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | `adapter.capabilities()` | `supportedChannels = {5, 9}` |
+| 2 | `angleOfArrivalSupported` | `true` |
+| 3 | `supportedRoles` | Contains CONTROLLER and CONTROLEE |
+
+### I3. Session Preparation (single device)
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | `IosPreparedSession.create(config)` | Completes within 5s timeout |
+| 2 | `localParams` non-empty | Starts with version byte `0x81` |
+| 3 | Deserialize token from `localParams` bytes | Returns valid `NIDiscoveryToken` |
+| 4 | Serialize → deserialize round-trip | Produces equivalent token |
+
+### I4. Full Ranging (two devices)
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | Device A: prepare session | Gets discovery token in `localParams` |
+| 2 | Device B: prepare session | Gets discovery token in `localParams` |
+| 3 | Exchange tokens over BLE (or manually) | Both devices have remote params |
+| 4 | Both: `startRanging(remoteParams)` | State → Ranging |
+| 5 | Hold devices ~1m apart | `distance ~1.0m`, azimuth/elevation present |
+| 6 | Verify `DiscoveryTokenCache` | Same peer token → same `PeerAddress` across callbacks |
+
+### I5. Session Lifecycle (two devices)
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | Active session, call `close()` | State → `Stopped.ByRequest`, NISession invalidated |
+| 2 | Move device out of range | `didRemoveNearbyObjects` → `PeerLost` |
+| 3 | Bring back in range | `didUpdateNearbyObjects` resumes |
+| 4 | Background app during ranging | `sessionWasSuspended` → `Active.Suspended` |
+| 5 | Foreground app | `sessionSuspensionEnded` → `Active.Ranging` |
+| 6 | Kill remote app | `didInvalidateWithError` → `Stopped.ByError` |
+
+---
+
+## Cross-Platform Ranging
+
+UWB ranging between Android and iOS is supported via the OOB parameter exchange:
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | Android CONTROLLER + iOS CONTROLEE | Both get `localParams` |
+| 2 | Exchange params (version bytes differ: 0x01 vs 0x81) | Each side decodes peer's format |
+| 3 | Start ranging | Measurements flow on both devices |
+
+**Note:** Cross-platform requires the OOB connector to handle the version byte dispatch. The `kmp-uwb-connector` module's `BleConnector` handles this transparently.
+
+---
+
+## Pass Criteria
+
+All tests in each section must pass. Any failure blocks the release.
+
+- Distance measurements within ±30% of actual distance at ranges < 5m
+- Azimuth measurements within ±15 degrees (device-dependent)
+- State transitions match the expected column exactly
+- No crashes, ANRs, or unhandled exceptions during any test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,10 @@ kotlin {
                 .toInt()
 
         withHostTestBuilder {}.configure {}
+
+        withDeviceTestBuilder {}.configure {
+            instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        }
     }
 
     jvm()
@@ -68,6 +72,24 @@ kotlin {
             implementation(libs.androidx.core)
             implementation(libs.androidx.core.uwb)
             implementation(libs.androidx.startup)
+        }
+        val androidHostTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.robolectric)
+                implementation(libs.androidx.test.core)
+            }
+        }
+        val androidDeviceTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.turbine)
+                implementation(libs.androidx.test.core)
+                implementation(libs.androidx.test.runner)
+                implementation(libs.androidx.test.ext.junit)
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,10 @@ androidCompileSdk = "36"
 androidx-core = "1.18.0"
 androidx-core-uwb = "1.0.0-beta01"
 turbine = "1.2.1"
+robolectric = "4.14.1"
+androidx-test-core = "1.6.1"
+androidx-test-runner = "1.6.2"
+androidx-test-ext-junit = "1.2.1"
 
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
@@ -25,6 +29,10 @@ androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.2
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 kmp-ble = { module = "com.atruedev:kmp-ble", version = "v0.3.7" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivityCompose" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+androidx-test-core = { module = "androidx.test:core-ktx", version.ref = "androidx-test-core" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-test-ext-junit" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/src/androidDeviceTest/kotlin/com/atruedev/kmpuwb/adapter/KmpUwbInstrumentedTest.kt
+++ b/src/androidDeviceTest/kotlin/com/atruedev/kmpuwb/adapter/KmpUwbInstrumentedTest.kt
@@ -1,0 +1,28 @@
+package com.atruedev.kmpuwb.adapter
+
+import android.app.Application
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+@RunWith(AndroidJUnit4::class)
+class KmpUwbInstrumentedTest {
+    @Test
+    fun requireContextDoesNotThrowAfterStartup() {
+        // AndroidX Startup should have already initialized KmpUwb
+        val context = KmpUwb.requireContext()
+        assertNotNull(context)
+    }
+
+    @Test
+    fun requireContextReturnsApplicationContext() {
+        val context = KmpUwb.requireContext()
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        assertIs<Application>(context)
+        // Should be the same application instance
+        kotlin.test.assertEquals(appContext, context)
+    }
+}

--- a/src/androidDeviceTest/kotlin/com/atruedev/kmpuwb/adapter/UwbAdapterInstrumentedTest.kt
+++ b/src/androidDeviceTest/kotlin/com/atruedev/kmpuwb/adapter/UwbAdapterInstrumentedTest.kt
@@ -1,0 +1,62 @@
+package com.atruedev.kmpuwb.adapter
+
+import android.content.pm.PackageManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.test.runTest
+import org.junit.Assume
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class UwbAdapterInstrumentedTest {
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val hasUwb: Boolean
+        get() = context.packageManager.hasSystemFeature(PackageManager.FEATURE_UWB)
+
+    @Test
+    fun adapterFactoryReturnsNonNull() {
+        val adapter = UwbAdapter()
+        assertNotNull(adapter)
+        adapter.close()
+    }
+
+    @Test
+    fun adapterReportsUnsupportedOnNonUwbDevice() {
+        Assume.assumeFalse("Device has UWB — skipping UNSUPPORTED test", hasUwb)
+        val adapter = UwbAdapter()
+        assertEquals(UwbAdapterState.UNSUPPORTED, adapter.state.value)
+        adapter.close()
+    }
+
+    @Test
+    fun capabilitiesReturnNoneOnNonUwbDevice() =
+        runTest {
+            Assume.assumeFalse("Device has UWB — skipping NONE capabilities test", hasUwb)
+            val adapter = UwbAdapter()
+            assertEquals(UwbCapabilities.NONE, adapter.capabilities())
+            adapter.close()
+        }
+
+    @Test
+    fun adapterReportsOnWhenUwbAvailable() {
+        Assume.assumeTrue("UWB hardware required", hasUwb)
+        val adapter = UwbAdapter()
+        assertEquals(UwbAdapterState.ON, adapter.state.value)
+        adapter.close()
+    }
+
+    @Test
+    fun capabilitiesNonEmptyOnUwbDevice() =
+        runTest {
+            Assume.assumeTrue("UWB hardware required", hasUwb)
+            val adapter = UwbAdapter()
+            val capabilities = adapter.capabilities()
+            assertTrue(capabilities.supportedChannels.isNotEmpty())
+            adapter.close()
+        }
+}

--- a/src/androidDeviceTest/kotlin/com/atruedev/kmpuwb/session/PreparedSessionGuardTest.kt
+++ b/src/androidDeviceTest/kotlin/com/atruedev/kmpuwb/session/PreparedSessionGuardTest.kt
@@ -1,0 +1,80 @@
+package com.atruedev.kmpuwb.session
+
+import android.content.pm.PackageManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.atruedev.kmpuwb.adapter.UwbAdapter
+import com.atruedev.kmpuwb.config.RangingRole
+import com.atruedev.kmpuwb.config.rangingConfig
+import kotlinx.coroutines.test.runTest
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests PreparedSession lifecycle guards on real UWB hardware.
+ * All tests are skipped on devices without UWB support.
+ */
+@RunWith(AndroidJUnit4::class)
+class PreparedSessionGuardTest {
+    @Before
+    fun requireUwbHardware() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        Assume.assumeTrue(
+            "UWB hardware required",
+            context.packageManager.hasSystemFeature(PackageManager.FEATURE_UWB),
+        )
+    }
+
+    @Test
+    fun prepareSessionReturnsNonEmptyLocalParams() =
+        runTest {
+            val adapter = UwbAdapter()
+            val config =
+                rangingConfig {
+                    role = RangingRole.CONTROLLER
+                    sessionId = 1
+                }
+            val prepared = adapter.prepareSession(config)
+            assertTrue(prepared.localParams.toByteArray().isNotEmpty())
+            prepared.close()
+            adapter.close()
+        }
+
+    @Test
+    fun localParamsDecodesCorrectly() =
+        runTest {
+            val adapter = UwbAdapter()
+            val config =
+                rangingConfig {
+                    role = RangingRole.CONTROLLER
+                    sessionId = 42
+                }
+            val prepared = adapter.prepareSession(config)
+            val decoded = SessionParamsCodec.decode(prepared.localParams)
+            assertTrue(decoded.address.isNotEmpty())
+            assertTrue(decoded.channel > 0)
+            prepared.close()
+            adapter.close()
+        }
+
+    @Test
+    fun closePreventsFurtherStartRanging() =
+        runTest {
+            val adapter = UwbAdapter()
+            val config =
+                rangingConfig {
+                    role = RangingRole.CONTROLLER
+                    sessionId = 1
+                }
+            val prepared = adapter.prepareSession(config)
+            prepared.close()
+            assertFailsWith<IllegalStateException> {
+                prepared.startRanging(SessionParams(byteArrayOf(0x01, 0x02)))
+            }
+            adapter.close()
+        }
+}

--- a/src/androidDeviceTest/kotlin/com/atruedev/kmpuwb/session/SessionParamsCodecInstrumentedTest.kt
+++ b/src/androidDeviceTest/kotlin/com/atruedev/kmpuwb/session/SessionParamsCodecInstrumentedTest.kt
@@ -1,0 +1,66 @@
+package com.atruedev.kmpuwb.session
+
+import androidx.core.uwb.UwbAddress
+import androidx.core.uwb.UwbComplexChannel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+/**
+ * Runs a subset of SessionParamsCodec tests on a real Android device/emulator
+ * to validate against real framework classes (catches Robolectric shadow fidelity issues).
+ */
+@RunWith(AndroidJUnit4::class)
+class SessionParamsCodecInstrumentedTest {
+    @Test
+    fun roundTripEncodeDecodeOnDevice() {
+        val address = byteArrayOf(0xAB.toByte(), 0xCD.toByte())
+        val channel = 9
+        val preambleIndex = 10
+        val sessionId = 42
+
+        val encoded =
+            SessionParamsCodec.encode(
+                address = UwbAddress(address),
+                complexChannel = UwbComplexChannel(channel, preambleIndex),
+                sessionId = sessionId,
+            )
+
+        val decoded = SessionParamsCodec.decode(encoded)
+
+        assertContentEquals(address, decoded.address)
+        assertEquals(channel, decoded.channel)
+        assertEquals(preambleIndex, decoded.preambleIndex)
+        assertEquals(sessionId, decoded.sessionId)
+    }
+
+    @Test
+    fun wireFormatMatchesSpecOnDevice() {
+        val address = byteArrayOf(0x01, 0x02)
+        val channel = 9
+        val preambleIndex = 5
+        val sessionId = 0x12345678
+
+        val encoded =
+            SessionParamsCodec.encode(
+                address = UwbAddress(address),
+                complexChannel = UwbComplexChannel(channel, preambleIndex),
+                sessionId = sessionId,
+            )
+
+        val bytes = encoded.toByteArray()
+        assertEquals(0x01, bytes[0]) // version
+        assertEquals(2, bytes[1].toInt()) // addressLen
+        assertEquals(0x01, bytes[2]) // address[0]
+        assertEquals(0x02, bytes[3]) // address[1]
+        assertEquals(channel.toByte(), bytes[4]) // channel
+        assertEquals(preambleIndex.toByte(), bytes[5]) // preambleIndex
+
+        val sessionIdBytes = ByteBuffer.wrap(bytes, 6, 4).order(ByteOrder.BIG_ENDIAN).int
+        assertEquals(sessionId, sessionIdBytes)
+    }
+}

--- a/src/androidHostTest/kotlin/com/atruedev/kmpuwb/adapter/AndroidUwbAdapterStateTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpuwb/adapter/AndroidUwbAdapterStateTest.kt
@@ -1,0 +1,40 @@
+package com.atruedev.kmpuwb.adapter
+
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidUwbAdapterStateTest {
+    @BeforeTest
+    fun initContext() {
+        KmpUwb.init(RuntimeEnvironment.getApplication())
+    }
+
+    @Test
+    fun stateIsUnsupportedWhenFeatureUwbAbsent() {
+        // Robolectric's default PackageManager does not include FEATURE_UWB,
+        // so AndroidUwbAdapter should resolve to UNSUPPORTED.
+        val adapter = UwbAdapter()
+        assertEquals(UwbAdapterState.UNSUPPORTED, adapter.state.value)
+    }
+
+    @Test
+    fun capabilitiesReturnsNoneWhenUnsupported() =
+        runTest {
+            val adapter = UwbAdapter()
+            val capabilities = adapter.capabilities()
+            assertEquals(UwbCapabilities.NONE, capabilities)
+        }
+
+    @Test
+    fun factoryReturnsNonNullAdapter() {
+        val adapter = UwbAdapter()
+        // The adapter should be non-null and closeable without error
+        adapter.close()
+    }
+}

--- a/src/androidHostTest/kotlin/com/atruedev/kmpuwb/adapter/KmpUwbInitTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpuwb/adapter/KmpUwbInitTest.kt
@@ -1,0 +1,70 @@
+package com.atruedev.kmpuwb.adapter
+
+import android.app.Application
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+@RunWith(RobolectricTestRunner::class)
+class KmpUwbInitTest {
+    @BeforeTest
+    fun resetKmpUwb() {
+        // Reset the lateinit field via reflection so each test starts clean
+        val field = KmpUwb::class.java.getDeclaredField("appContext")
+        field.isAccessible = true
+        // Use the underlying delegate to clear it — set to a sentinel we can detect
+        // Actually, we need to check if it's initialized first. For lateinit, we use
+        // the Kotlin reflection approach:
+        try {
+            // Force-clear by setting accessible and nulling the backing field
+            val backingField = KmpUwb::class.java.getDeclaredField("appContext")
+            backingField.isAccessible = true
+            // lateinit backing fields are non-null in Kotlin but nullable in JVM bytecode
+            @Suppress("UNCHECKED_CAST")
+            (backingField as java.lang.reflect.Field).set(KmpUwb, null)
+        } catch (_: Exception) {
+            // Field may already be unset
+        }
+    }
+
+    @Test
+    fun requireContextThrowsBeforeInit() {
+        assertFailsWith<IllegalStateException> {
+            KmpUwb.requireContext()
+        }
+    }
+
+    @Test
+    fun initStoresApplicationContext() {
+        val appContext = RuntimeEnvironment.getApplication()
+        KmpUwb.init(appContext)
+
+        val result = KmpUwb.requireContext()
+        assertIs<Application>(result)
+    }
+
+    @Test
+    fun initWithActivityContextStoresApplicationContext() {
+        val appContext = RuntimeEnvironment.getApplication()
+        // Passing the application context directly (Robolectric doesn't easily create Activity contexts)
+        // The key behavior: context.applicationContext is called in init()
+        KmpUwb.init(appContext)
+
+        val result = KmpUwb.requireContext()
+        assertEquals(appContext.applicationContext, result)
+    }
+
+    @Test
+    fun doubleInitDoesNotCrash() {
+        val context = RuntimeEnvironment.getApplication()
+        KmpUwb.init(context)
+        KmpUwb.init(context)
+        // If we get here without exception, the test passes
+        KmpUwb.requireContext()
+    }
+}

--- a/src/androidHostTest/kotlin/com/atruedev/kmpuwb/session/AndroidRangingResultMapperTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpuwb/session/AndroidRangingResultMapperTest.kt
@@ -1,0 +1,145 @@
+package com.atruedev.kmpuwb.session
+
+import androidx.core.uwb.RangingPosition
+import androidx.core.uwb.UwbAddress
+import androidx.core.uwb.UwbDevice
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import androidx.core.uwb.RangingMeasurement as AndroidRangingMeasurement
+import androidx.core.uwb.RangingResult as AndroidRangingResult
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidRangingResultMapperTest {
+    private val testAddress = byteArrayOf(0x01, 0x02)
+    private val testDevice = UwbDevice(UwbAddress(testAddress))
+
+    @Test
+    fun positionResultMapsDistanceAzimuthElevation() {
+        val position =
+            RangingPosition(
+                distance = AndroidRangingMeasurement(2.5f),
+                azimuth = AndroidRangingMeasurement(15.0f),
+                elevation = AndroidRangingMeasurement(-10.0f),
+                elapsedRealtimeNanos = 0L,
+            )
+        val platformResult = AndroidRangingResult.RangingResultPosition(testDevice, position)
+
+        val result = platformResult.toRangingResult()
+
+        assertNotNull(result)
+        assertIs<RangingResult.Position>(result)
+        assertEquals(2.5, result.measurement.distance?.meters)
+        assertEquals(15.0, result.measurement.azimuth?.degrees)
+        assertEquals(-10.0, result.measurement.elevation?.degrees)
+    }
+
+    @Test
+    fun positionResultWithNullDistanceMapsToNull() {
+        val position =
+            RangingPosition(
+                distance = null,
+                azimuth = AndroidRangingMeasurement(5.0f),
+                elevation = null,
+                elapsedRealtimeNanos = 0L,
+            )
+        val platformResult = AndroidRangingResult.RangingResultPosition(testDevice, position)
+
+        val result = platformResult.toRangingResult()
+
+        assertNotNull(result)
+        assertIs<RangingResult.Position>(result)
+        assertNull(result.measurement.distance)
+        assertNotNull(result.measurement.azimuth)
+        assertNull(result.measurement.elevation)
+    }
+
+    @Test
+    fun positionResultWithAllNullMeasurements() {
+        val position =
+            RangingPosition(
+                distance = null,
+                azimuth = null,
+                elevation = null,
+                elapsedRealtimeNanos = 0L,
+            )
+        val platformResult = AndroidRangingResult.RangingResultPosition(testDevice, position)
+
+        val result = platformResult.toRangingResult()
+
+        assertNotNull(result)
+        assertIs<RangingResult.Position>(result)
+        assertNull(result.measurement.distance)
+        assertNull(result.measurement.azimuth)
+        assertNull(result.measurement.elevation)
+    }
+
+    @Test
+    fun peerDisconnectedMapsToPeerLost() {
+        val platformResult = AndroidRangingResult.RangingResultPeerDisconnected(testDevice, 0)
+
+        val result = platformResult.toRangingResult()
+
+        assertNotNull(result)
+        assertIs<RangingResult.PeerLost>(result)
+    }
+
+    @Test
+    fun peerAddressPreservedInPosition() {
+        val position =
+            RangingPosition(
+                distance = AndroidRangingMeasurement(1.0f),
+                azimuth = null,
+                elevation = null,
+                elapsedRealtimeNanos = 0L,
+            )
+        val platformResult = AndroidRangingResult.RangingResultPosition(testDevice, position)
+
+        val result = platformResult.toRangingResult()
+
+        assertIs<RangingResult.Position>(result)
+        assertEquals(
+            testAddress.toList(),
+            result.peer.address
+                .toByteArray()
+                .toList(),
+        )
+    }
+
+    @Test
+    fun peerAddressPreservedInPeerLost() {
+        val platformResult = AndroidRangingResult.RangingResultPeerDisconnected(testDevice, 0)
+
+        val result = platformResult.toRangingResult()
+
+        assertIs<RangingResult.PeerLost>(result)
+        assertEquals(
+            testAddress.toList(),
+            result.peer.address
+                .toByteArray()
+                .toList(),
+        )
+    }
+
+    @Test
+    fun initializedResultReturnsNull() {
+        val platformResult = AndroidRangingResult.RangingResultInitialized(testDevice)
+
+        val result = platformResult.toRangingResult()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun failureResultReturnsNull() {
+        val platformResult = AndroidRangingResult.RangingResultFailure(testDevice, 0)
+
+        val result = platformResult.toRangingResult()
+
+        assertNull(result)
+    }
+}

--- a/src/androidHostTest/kotlin/com/atruedev/kmpuwb/session/SessionParamsCodecTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpuwb/session/SessionParamsCodecTest.kt
@@ -1,0 +1,189 @@
+package com.atruedev.kmpuwb.session
+
+import androidx.core.uwb.UwbAddress
+import androidx.core.uwb.UwbComplexChannel
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@RunWith(RobolectricTestRunner::class)
+class SessionParamsCodecTest {
+    @Test
+    fun roundTripEncodeDecodePreservesAllFields() {
+        val address = byteArrayOf(0xAB.toByte(), 0xCD.toByte())
+        val channel = 9
+        val preambleIndex = 10
+        val sessionId = 42
+
+        val encoded =
+            SessionParamsCodec.encode(
+                address = UwbAddress(address),
+                complexChannel = UwbComplexChannel(channel, preambleIndex),
+                sessionId = sessionId,
+            )
+
+        val decoded = SessionParamsCodec.decode(encoded)
+
+        assertContentEquals(address, decoded.address)
+        assertEquals(channel, decoded.channel)
+        assertEquals(preambleIndex, decoded.preambleIndex)
+        assertEquals(sessionId, decoded.sessionId)
+    }
+
+    @Test
+    fun wireFormatMatchesSpec() {
+        val address = byteArrayOf(0x01, 0x02)
+        val channel = 9
+        val preambleIndex = 5
+        val sessionId = 0x12345678
+
+        val encoded =
+            SessionParamsCodec.encode(
+                address = UwbAddress(address),
+                complexChannel = UwbComplexChannel(channel, preambleIndex),
+                sessionId = sessionId,
+            )
+
+        val bytes = encoded.toByteArray()
+        assertEquals(0x01, bytes[0]) // version
+        assertEquals(2, bytes[1].toInt()) // addressLen
+        assertEquals(0x01, bytes[2]) // address[0]
+        assertEquals(0x02, bytes[3]) // address[1]
+        assertEquals(channel.toByte(), bytes[4]) // channel
+        assertEquals(preambleIndex.toByte(), bytes[5]) // preambleIndex
+
+        // sessionId as big-endian int
+        val sessionIdBytes = ByteBuffer.wrap(bytes, 6, 4).order(ByteOrder.BIG_ENDIAN).int
+        assertEquals(sessionId, sessionIdBytes)
+    }
+
+    @Test
+    fun variableLengthAddress1Byte() {
+        val address = byteArrayOf(0xFF.toByte())
+        val encoded =
+            SessionParamsCodec.encode(
+                address = UwbAddress(address),
+                complexChannel = UwbComplexChannel(5, 0),
+                sessionId = 1,
+            )
+        val decoded = SessionParamsCodec.decode(encoded)
+        assertContentEquals(address, decoded.address)
+    }
+
+    @Test
+    fun variableLengthAddress8Bytes() {
+        val address = ByteArray(8) { it.toByte() }
+        val encoded =
+            SessionParamsCodec.encode(
+                address = UwbAddress(address),
+                complexChannel = UwbComplexChannel(9, 3),
+                sessionId = 99,
+            )
+        val decoded = SessionParamsCodec.decode(encoded)
+        assertContentEquals(address, decoded.address)
+        assertEquals(8, decoded.address.size)
+    }
+
+    @Test
+    fun decodeRejectsWrongVersion() {
+        val bytes =
+            byteArrayOf(
+                0x81.toByte(), // iOS version instead of Android
+                0x02,
+                0x01,
+                0x02, // address
+                0x09,
+                0x00, // channel, preamble
+                0x00,
+                0x00,
+                0x00,
+                0x01, // sessionId
+            )
+        assertFailsWith<IllegalArgumentException> {
+            SessionParamsCodec.decode(SessionParams(bytes))
+        }
+    }
+
+    @Test
+    fun decodeRejectsTruncatedHeader() {
+        val bytes = byteArrayOf(0x01) // only version, no addressLen
+        assertFailsWith<IllegalArgumentException> {
+            SessionParamsCodec.decode(SessionParams(bytes))
+        }
+    }
+
+    @Test
+    fun decodeRejectsTruncatedBody() {
+        val bytes =
+            byteArrayOf(
+                0x01, // version
+                0x04, // addressLen = 4, but only 2 bytes of address follow
+                0x01,
+                0x02,
+            )
+        assertFailsWith<IllegalArgumentException> {
+            SessionParamsCodec.decode(SessionParams(bytes))
+        }
+    }
+
+    @Test
+    fun sessionIdMaxValue() {
+        val encoded =
+            SessionParamsCodec.encode(
+                address = UwbAddress(byteArrayOf(0x01)),
+                complexChannel = UwbComplexChannel(9, 0),
+                sessionId = Int.MAX_VALUE,
+            )
+        val decoded = SessionParamsCodec.decode(encoded)
+        assertEquals(Int.MAX_VALUE, decoded.sessionId)
+    }
+
+    @Test
+    fun sessionIdMinValue() {
+        val encoded =
+            SessionParamsCodec.encode(
+                address = UwbAddress(byteArrayOf(0x01)),
+                complexChannel = UwbComplexChannel(9, 0),
+                sessionId = Int.MIN_VALUE,
+            )
+        val decoded = SessionParamsCodec.decode(encoded)
+        assertEquals(Int.MIN_VALUE, decoded.sessionId)
+    }
+
+    @Test
+    fun sessionIdZero() {
+        val encoded =
+            SessionParamsCodec.encode(
+                address = UwbAddress(byteArrayOf(0x01)),
+                complexChannel = UwbComplexChannel(9, 0),
+                sessionId = 0,
+            )
+        val decoded = SessionParamsCodec.decode(encoded)
+        assertEquals(0, decoded.sessionId)
+    }
+
+    @Test
+    fun decodedParamsEquality() {
+        val a =
+            SessionParamsCodec.DecodedParams(
+                address = byteArrayOf(0x01, 0x02),
+                channel = 9,
+                preambleIndex = 5,
+                sessionId = 42,
+            )
+        val b =
+            SessionParamsCodec.DecodedParams(
+                address = byteArrayOf(0x01, 0x02),
+                channel = 9,
+                preambleIndex = 5,
+                sessionId = 42,
+            )
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+}


### PR DESCRIPTION
## Summary

- Add 26 Robolectric host tests across 4 test classes covering `SessionParamsCodec`, `AndroidRangingResultMapper`, `KmpUwb` init, and `AndroidUwbAdapter` state resolution
- Add 12 on-device instrumented tests across 4 test classes for AndroidX Startup verification, adapter factory, codec on real framework, and hardware-conditional session lifecycle guards
- Add `android-instrumented` CI job using `reactivecircus/android-emulator-runner` on API 33 emulator
- Add `HARDWARE_TEST_PLAN.md` documenting manual pre-release test matrix for Android and iOS UWB devices
- Configure `withDeviceTestBuilder` and wire Robolectric + AndroidX Test dependencies

## Test plan

- [x] `./gradlew testAndroidHostTest` — 108 tests pass (26 new + 82 existing common tests), 0 failures
- [x] `./gradlew ktlintCheck` — no violations
- [ ] `./gradlew connectedAndroidDeviceTest` — runs on API 33 emulator in CI (hardware tests skipped via `Assume`)
- [ ] Existing `./gradlew iosSimulatorArm64Test` still passes (no regression)