### PR TITLE
feat: add configurable BackpressureStrategy for ranging measurements

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,22 +105,23 @@ Layer 3: Consumer API (caller's coroutine context)
 ### Hot Flow with Bounded Buffer
 
 ```kotlin
-private val resultChannel = Channel<RangingResult>(
-    capacity = 64,
-    onBufferOverflow = BufferOverflow.DROP_OLDEST,
-)
+private val resultChannel = createResultChannel(config.backpressureStrategy)
 override val rangingResults: Flow<RangingResult> = resultChannel.receiveAsFlow()
 ```
 
 UWB measurements arrive at high frequency (~5 Hz). The pipeline is designed for this:
 
-- **`Channel(64, DROP_OLDEST)`** — if a consumer falls behind, stale measurements are silently dropped. The consumer always sees the most recent data.
+- **Configurable `BackpressureStrategy`** — consumers choose how buffering behaves:
+  - `Latest` (default): `Channel(64, DROP_OLDEST)` — stale measurements dropped, consumer sees latest data
+  - `Buffer`: `Channel(UNLIMITED)` — all measurements buffered for analytics/replay
+  - `Drop`: `Channel(64, DROP_LATEST)` — newest measurements dropped, strict arrival order preserved
 - **`receiveAsFlow()`** — converts the channel to a cold-on-subscription Flow. Unlike `channelFlow`, this doesn't start a new platform session per collector.
 - **`trySend()`** — non-suspending send from platform callbacks. Never blocks the OS callback thread.
+- **`createResultChannel()`** — shared factory in `commonMain` used by both Android and iOS, avoiding duplicated channel construction logic.
 
 ### Why Not SharedFlow?
 
-`MutableSharedFlow(replay=0)` drops values when no collector is active. `MutableSharedFlow(replay=1)` replays stale data to new collectors. The channel approach gives explicit buffer control with `DROP_OLDEST` semantics — the right trade-off for real-time sensor data.
+`MutableSharedFlow(replay=0)` drops values when no collector is active. `MutableSharedFlow(replay=1)` replays stale data to new collectors. The channel approach gives explicit buffer control — the right trade-off for real-time sensor data.
 
 ### Single Session Start
 
@@ -287,7 +288,7 @@ fake.simulateUnsupported() // state → UNSUPPORTED
 |----------|-----------|
 | Separate repo from kmp-ble | Different hardware, different APIs, different release cadence. No compile-time coupling |
 | `expect/actual` factory functions | `UwbAdapter()` and `RangingSession(config)` look like constructors but dispatch to platform implementations. No DI framework required |
-| Channel over SharedFlow | Explicit buffer control with `DROP_OLDEST` for real-time sensor data |
+| Channel over SharedFlow | Explicit buffer control via configurable `BackpressureStrategy` for real-time sensor data |
 | Content-based PeerAddress | `ByteArray` referential equality is a footgun. Regular class with `contentEquals` prevents subtle bugs |
 | Single-writer concurrency | `limitedParallelism(1)` serializes all state mutations per session without locks |
 | JVM stubs | Lets common tests run on host. Desktop UWB is not a current target |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Changes on `main` that have not yet been tagged for release._
+### Added
+- Configurable `BackpressureStrategy` for ranging measurements: Latest, Buffer, Drop (#36)
+- `kmp-uwb-connector` module documentation in README (#37)
+- BLE + UWB out-of-band integration guide (#39)
+- CONTRIBUTING.md with versioning and release criteria (#38)
+- 1.0 release checklist in ROADMAP.md (#40)
+
+### Changed
+- Extract shared `createResultChannel()` factory for Android and iOS ranging pipelines
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to kmp-uwb
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### Pre-1.0 (current)
+
+| Bump | Criteria | Example |
+|------|----------|---------|
+| **Patch** (0.1.x -> 0.1.y) | Bug fixes, documentation, CI changes. No public API changes | Fix crash in iOS session delegate |
+| **Minor** (0.1.x -> 0.2.0) | New features, deprecations, non-breaking API additions | Add `BackpressureStrategy`, new `RangingResult` variant |
+| **Breaking** (0.x -> 0.y) | Removed or renamed public API, changed signatures | Remove deprecated `start()` method |
+
+Breaking changes are documented in the CHANGELOG with migration instructions.
+
+### Post-1.0
+
+| Bump | Criteria |
+|------|----------|
+| **Patch** (1.0.x) | Bug fixes only, no API changes |
+| **Minor** (1.x.0) | Backwards-compatible additions and deprecations |
+| **Major** (x.0.0) | Breaking changes. Deprecated APIs removed after surviving at least 1 minor release |
+
+## Release Process
+
+1. Changes land on `main` via pull request
+2. CI validates: ktlint, Android build/test, iOS build/test
+3. Tag `vX.Y.Z` triggers publish to Maven Central and GitHub Releases
+4. iOS XCFramework and `Package.swift` are updated automatically
+
+## Development
+
+### Prerequisites
+
+- JDK 17+
+- Android SDK (API 33+)
+- Xcode 15+ (for iOS targets)
+
+### Build
+
+```bash
+./gradlew build
+```
+
+### Test
+
+```bash
+# Common + JVM + Android host tests
+./gradlew check
+
+# iOS tests (requires macOS + Xcode)
+./gradlew iosSimulatorArm64Test
+
+# Android instrumented tests (requires device/emulator)
+./gradlew connectedAndroidTest
+```
+
+### Code Style
+
+This project uses [ktlint](https://pinterest.github.io/ktlint/). The CI enforces formatting.
+
+```bash
+./gradlew ktlintCheck    # verify
+./gradlew ktlintFormat   # auto-fix
+```
+
+## Pull Requests
+
+- One logical change per PR
+- Include tests for new functionality
+- Update CHANGELOG.md under `[Unreleased]`
+- Keep commit messages concise: `type(scope): description` (e.g., `feat(config): add BackpressureStrategy`)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Part of the **kmp** library family alongside [kmp-ble](https://github.com/gary-q
 | **Test Without Hardware** | `FakeRangingSession` and `FakeUwbAdapter` for full UWB simulation in unit tests |
 | **FiRa Compliant** | Static, Dynamic, and Provisioned STS security modes. Controller/Controlee roles |
 
+## Modules
+
+| Module | Artifact | Description |
+|--------|----------|-------------|
+| **kmp-uwb** | `com.atruedev:kmp-uwb` | Core UWB library — adapter, sessions, ranging, state machine |
+| **kmp-uwb-connector** | `com.atruedev:kmp-uwb-connector` | BLE-based out-of-band parameter exchange using [kmp-ble](https://github.com/gary-quinn/kmp-ble) |
+| **kmp-uwb-testing** | `com.atruedev:kmp-uwb-testing` | Test doubles — `FakeRangingSession`, `FakeUwbAdapter`, `FakePreparedSession` |
+
 ## Setup
 
 ### Android / KMP (Gradle)
@@ -157,6 +165,91 @@ fakeSession.emitResult(
 fakeSession.simulateError(SessionLost(message = "connection dropped"))
 ```
 
+### Configure backpressure
+
+```kotlin
+val config = rangingConfig {
+    role = RangingRole.CONTROLLER
+    backpressureStrategy = BackpressureStrategy.Buffer // keep every measurement
+}
+```
+
+| Strategy | Behavior | Use case |
+|----------|----------|----------|
+| `Latest` (default) | Drop oldest when buffer full | Real-time UI |
+| `Buffer` | Unbounded buffer | Analytics, replay |
+| `Drop` | Drop newest when buffer full | Strict arrival order processing |
+
+## kmp-uwb-connector
+
+The connector module automates BLE-based out-of-band (OOB) parameter exchange — the handshake every UWB session requires before ranging can start.
+
+```kotlin
+// Add the connector dependency alongside the core module
+commonMain.dependencies {
+    implementation("com.atruedev:kmp-uwb-connector:<latest-version>")
+}
+```
+
+### Controller side
+
+```kotlin
+val scanner = Scanner { filters { match { serviceUuid(UwbOobService.SERVICE_UUID) } } }
+val connector = BleConnector.controller(scanner)
+
+try {
+    val session = adapter.startWithConnector(config, connector)
+    session.rangingResults.collect { result -> /* ... */ }
+} catch (e: ConnectorException) {
+    when (e.error) {
+        is ExchangeTimedOut -> println("No peer found")
+        is TransportFailure -> println("BLE failed: ${e.message}")
+        is InvalidRemoteParams -> println("Bad params: ${e.message}")
+    }
+}
+```
+
+### Controlee side
+
+```kotlin
+val connector = BleConnector.controlee()
+val session = adapter.startWithConnector(config, connector)
+```
+
+### BLE + UWB integration flow
+
+A complete ranging session requires both BLE (for discovery and parameter exchange) and UWB (for ranging). The typical flow:
+
+```
+Controller                              Controlee
+    │                                       │
+    │  1. BLE scan for UwbOobService UUID   │
+    │ ────────────────────────────────────>  │  ← BLE advertise
+    │                                       │
+    │  2. BLE connect                       │
+    │ ────────────────────────────────────>  │
+    │                                       │
+    │  3. Write local UWB params            │
+    │ ────────────────────────────────────>  │  ← GATT write
+    │                                       │
+    │  4. Read remote UWB params            │
+    │ <────────────────────────────────────  │  ← GATT indicate
+    │                                       │
+    │  5. UWB ranging session starts        │
+    │ <═══════════════════════════════════>  │  ← UWB TWR
+```
+
+`startWithConnector` orchestrates steps 1-5 automatically. For custom OOB transports (NFC, WiFi Direct), implement the `PeerConnector` interface:
+
+```kotlin
+val session = adapter.startWithConnector(config) { localParams ->
+    // Send localParams over your transport
+    myTransport.send(localParams.toByteArray())
+    // Receive remote params
+    SessionParams(myTransport.receive())
+}
+```
+
 ## Relationship with kmp-ble
 
 kmp-uwb and kmp-ble are **independent libraries** with no compile-time dependency. They share the same design philosophy:
@@ -176,7 +269,7 @@ A typical spatial app might use kmp-ble for device discovery and data exchange, 
 
 - **State machine:** 10 states with sealed interface hierarchy — exhaustive `when` branches
 - **Per-session concurrency:** `limitedParallelism(1)` serialization, no locks
-- **Hot Flow ranging:** `Channel(64, DROP_OLDEST)` — consumers always see the latest measurement
+- **Configurable backpressure:** `BackpressureStrategy` (Latest, Buffer, Drop) for ranging results pipeline
 - **Value classes:** `Distance` and `Angle` are zero-allocation wrappers with unit conversion
 - **Composable errors:** Sealed interfaces — `SessionError`, `RangingError`, `HardwareError`, `SecurityError`
 - **Defensive copies:** `PeerAddress` copies on construction and access — no aliasing bugs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,21 +68,29 @@ Everything needed to build production UWB ranging apps on Android and iOS from s
 
 **Theme:** API stability commitment backed by production usage.
 
-**Criteria:**
+**Checklist:**
 
-API stability:
-- Core module API (`UwbAdapter`, `RangingSession`, `RangingConfig`, `PreparedSession`) unchanged for 2+ minor releases
-- Deprecation cycle enforced: deprecated APIs survive at least 1 minor release before removal
-- All public APIs have KDoc documentation
+API surface:
+- [ ] Core APIs (`UwbAdapter`, `RangingSession`, `RangingConfig`, `PreparedSession`) unchanged for 2+ minor releases
+- [ ] API review with binary compatibility validation ([kotlinx-binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator))
+- [ ] Deprecation policy enforced: deprecated APIs survive at least 1 minor release before removal
+- [ ] All public APIs have KDoc documentation
 
 Quality:
-- Zero known critical bugs at release time
-- Test coverage for all public API entry points
-- CI green on both Android and iOS targets
+- [ ] Zero known critical bugs at release time
+- [ ] Test coverage for all public API entry points
+- [ ] iOS integration tests beyond commonTest
+- [ ] Hardware test plan executed with results documented
+- [ ] Performance benchmarks: ranging latency, battery impact
+
+Documentation:
+- [x] `kmp-uwb-connector` module documented in README
+- [x] BLE + UWB out-of-band integration guide
+- [x] Versioning and release criteria in CONTRIBUTING.md
 
 Distribution:
-- Semantic versioning strictly followed from v1.0 onward
-- CHANGELOG.md covers every release
+- [ ] Semantic versioning strictly followed from v1.0 onward
+- [ ] CHANGELOG.md covers every release
 
 ---
 

--- a/kmp-uwb-testing/src/commonMain/kotlin/com/atruedev/kmpuwb/testing/FakeRangingSession.kt
+++ b/kmp-uwb-testing/src/commonMain/kotlin/com/atruedev/kmpuwb/testing/FakeRangingSession.kt
@@ -34,6 +34,7 @@ public class FakeRangingSession(
     private val _state = MutableStateFlow(initialState)
     override val state: StateFlow<RangingState> = _state.asStateFlow()
 
+    // UNLIMITED regardless of config.backpressureStrategy — test emissions must never block.
     private val resultChannel = Channel<RangingResult>(capacity = Channel.UNLIMITED)
     override val rangingResults: Flow<RangingResult> = resultChannel.receiveAsFlow()
 

--- a/src/androidMain/kotlin/com/atruedev/kmpuwb/session/AndroidPreparedSession.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpuwb/session/AndroidPreparedSession.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -78,11 +77,7 @@ internal class AndroidPreparedSession(
                 SupervisorJob() + Dispatchers.Default.limitedParallelism(1) + CoroutineName("UwbRanging"),
             )
         val state = MutableStateFlow<RangingState>(RangingState.Starting.Negotiating)
-        val resultChannel =
-            Channel<RangingResult>(
-                capacity = 64,
-                onBufferOverflow = BufferOverflow.DROP_OLDEST,
-            )
+        val resultChannel = createResultChannel(config.backpressureStrategy)
 
         sessionScope.launch {
             try {

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/config/BackpressureStrategy.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/config/BackpressureStrategy.kt
@@ -1,0 +1,27 @@
+package com.atruedev.kmpuwb.config
+
+/**
+ * Controls how ranging measurements are buffered when the consumer falls behind.
+ *
+ * Matches the `BackpressureStrategy` pattern in kmp-ble for ecosystem consistency.
+ */
+public enum class BackpressureStrategy {
+    /**
+     * Drop the oldest buffered measurement when the buffer is full.
+     * The consumer always sees the most recent data. Default for real-time UIs.
+     */
+    Latest,
+
+    /**
+     * Buffer all measurements without dropping. Use for analytics or replay
+     * scenarios where every measurement matters. Unbounded — long-running
+     * sessions at high update rates will accumulate memory proportionally.
+     */
+    Buffer,
+
+    /**
+     * Drop the newest measurement when the buffer is full.
+     * The consumer processes measurements in strict arrival order.
+     */
+    Drop,
+}

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/config/RangingConfig.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/config/RangingConfig.kt
@@ -26,6 +26,8 @@ public data class RangingConfig(
     val channel: Int = DEFAULT_CHANNEL,
     /** Session identifier shared between controller and controlee. Used on both platforms. */
     val sessionId: Int = 0,
+    /** Controls how ranging measurements are buffered when the consumer falls behind. */
+    val backpressureStrategy: BackpressureStrategy = BackpressureStrategy.Latest,
     /** Pre-shared key for STS. Null uses platform-generated keys. Used on Android. */
     val sessionKey: ByteArray? = null,
 ) {
@@ -47,6 +49,7 @@ public data class RangingConfig(
             stsMode == other.stsMode &&
             channel == other.channel &&
             sessionId == other.sessionId &&
+            backpressureStrategy == other.backpressureStrategy &&
             sessionKey.contentEquals(other.sessionKey)
     }
 
@@ -57,6 +60,7 @@ public data class RangingConfig(
         result = 31 * result + stsMode.hashCode()
         result = 31 * result + channel
         result = 31 * result + sessionId
+        result = 31 * result + backpressureStrategy.hashCode()
         result = 31 * result + (sessionKey?.contentHashCode() ?: 0)
         return result
     }
@@ -78,6 +82,7 @@ public class RangingConfigBuilder {
     public var stsMode: StsMode = StsMode.DYNAMIC
     public var channel: Int = RangingConfig.DEFAULT_CHANNEL
     public var sessionId: Int = 0
+    public var backpressureStrategy: BackpressureStrategy = BackpressureStrategy.Latest
     public var sessionKey: ByteArray? = null
 
     public fun build(): RangingConfig =
@@ -88,6 +93,7 @@ public class RangingConfigBuilder {
             stsMode = stsMode,
             channel = channel,
             sessionId = sessionId,
+            backpressureStrategy = backpressureStrategy,
             sessionKey = sessionKey,
         )
 }

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/session/RangingSession.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/session/RangingSession.kt
@@ -12,8 +12,9 @@ import kotlinx.coroutines.flow.StateFlow
  * session parameters with a remote peer over an out-of-band transport.
  *
  * State transitions are observable via [state].
- * Ranging measurements are emitted via [rangingResults] with DROP_OLDEST
- * backpressure — stale measurements are discarded if the consumer falls behind.
+ * Ranging measurements are emitted via [rangingResults] using the
+ * [BackpressureStrategy][com.atruedev.kmpuwb.config.BackpressureStrategy]
+ * specified in [config].
  *
  * ```
  * val prepared = adapter.prepareSession(config)

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/session/ResultChannel.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/session/ResultChannel.kt
@@ -1,0 +1,14 @@
+package com.atruedev.kmpuwb.session
+
+import com.atruedev.kmpuwb.config.BackpressureStrategy
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+
+internal const val DEFAULT_BUFFER_CAPACITY = 64
+
+internal fun createResultChannel(strategy: BackpressureStrategy): Channel<RangingResult> =
+    when (strategy) {
+        BackpressureStrategy.Latest -> Channel(DEFAULT_BUFFER_CAPACITY, BufferOverflow.DROP_OLDEST)
+        BackpressureStrategy.Buffer -> Channel(Channel.UNLIMITED)
+        BackpressureStrategy.Drop -> Channel(DEFAULT_BUFFER_CAPACITY, BufferOverflow.DROP_LATEST)
+    }

--- a/src/commonTest/kotlin/com/atruedev/kmpuwb/config/BackpressureStrategyTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpuwb/config/BackpressureStrategyTest.kt
@@ -1,0 +1,22 @@
+package com.atruedev.kmpuwb.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BackpressureStrategyTest {
+    @Test
+    fun latestIsDefaultInRangingConfig() {
+        val config = rangingConfig { role = RangingRole.CONTROLEE }
+        assertEquals(BackpressureStrategy.Latest, config.backpressureStrategy)
+    }
+
+    @Test
+    fun dslBuilderAcceptsStrategy() {
+        val config =
+            rangingConfig {
+                role = RangingRole.CONTROLLER
+                backpressureStrategy = BackpressureStrategy.Buffer
+            }
+        assertEquals(BackpressureStrategy.Buffer, config.backpressureStrategy)
+    }
+}

--- a/src/commonTest/kotlin/com/atruedev/kmpuwb/config/RangingConfigTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpuwb/config/RangingConfigTest.kt
@@ -31,6 +31,7 @@ class RangingConfigTest {
         assertEquals(StsMode.DYNAMIC, config.stsMode)
         assertEquals(9, config.channel)
         assertEquals(0, config.sessionId)
+        assertEquals(BackpressureStrategy.Latest, config.backpressureStrategy)
     }
 
     @Test

--- a/src/commonTest/kotlin/com/atruedev/kmpuwb/session/ResultChannelTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpuwb/session/ResultChannelTest.kt
@@ -1,0 +1,69 @@
+package com.atruedev.kmpuwb.session
+
+import com.atruedev.kmpuwb.config.BackpressureStrategy
+import com.atruedev.kmpuwb.peer.Peer
+import com.atruedev.kmpuwb.peer.PeerAddress
+import com.atruedev.kmpuwb.ranging.Distance
+import com.atruedev.kmpuwb.ranging.RangingMeasurement
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ResultChannelTest {
+    @Test
+    fun latestDropsOldestWhenBufferFull() =
+        runTest {
+            val channel = createResultChannel(BackpressureStrategy.Latest)
+            val sent = DEFAULT_BUFFER_CAPACITY + 36
+            repeat(sent) { channel.trySend(positionAt(it)) }
+
+            val first = channel.tryReceive().getOrNull()
+            assertIs<RangingResult.Position>(first)
+            assertTrue(distanceOf(first) > 0, "Expected oldest items dropped")
+            channel.close()
+        }
+
+    @Test
+    fun bufferKeepsAllMeasurements() =
+        runTest {
+            val channel = createResultChannel(BackpressureStrategy.Buffer)
+            val sent = DEFAULT_BUFFER_CAPACITY * 3
+            repeat(sent) { channel.trySend(positionAt(it)) }
+
+            val first = channel.tryReceive().getOrNull()
+            assertIs<RangingResult.Position>(first)
+            assertEquals(0, distanceOf(first), "Expected no items dropped")
+            channel.close()
+        }
+
+    @Test
+    fun dropDiscardsNewestWhenBufferFull() =
+        runTest {
+            val channel = createResultChannel(BackpressureStrategy.Drop)
+            val sent = DEFAULT_BUFFER_CAPACITY + 36
+            repeat(sent) { channel.trySend(positionAt(it)) }
+
+            val first = channel.tryReceive().getOrNull()
+            assertIs<RangingResult.Position>(first)
+            assertEquals(0, distanceOf(first), "Expected oldest items retained")
+
+            // Drain all buffered items and count them
+            var count = 1
+            while (channel.tryReceive().isSuccess) count++
+            assertTrue(count <= DEFAULT_BUFFER_CAPACITY + 1, "Expected newest items dropped, got $count")
+            channel.close()
+        }
+
+    private fun positionAt(index: Int) =
+        RangingResult.Position(
+            peer = Peer(address = PeerAddress(byteArrayOf(index.toByte()))),
+            measurement = RangingMeasurement(distance = Distance.meters(index.toDouble())),
+        )
+
+    private fun distanceOf(result: RangingResult.Position): Int =
+        result.measurement.distance
+            ?.meters
+            ?.toInt() ?: -1
+}

--- a/src/iosMain/kotlin/com/atruedev/kmpuwb/session/IosRangingSession.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpuwb/session/IosRangingSession.kt
@@ -23,8 +23,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -60,11 +58,7 @@ internal class IosRangingSession(
     private val _state = MutableStateFlow<RangingState>(RangingState.Idle.Ready)
     override val state: StateFlow<RangingState> = _state.asStateFlow()
 
-    private val resultChannel =
-        Channel<RangingResult>(
-            capacity = 64,
-            onBufferOverflow = BufferOverflow.DROP_OLDEST,
-        )
+    private val resultChannel = createResultChannel(config.backpressureStrategy)
     override val rangingResults: Flow<RangingResult> = resultChannel.receiveAsFlow()
 
     private var niSession: NISession? = existingSession


### PR DESCRIPTION
## Summary

Add `BackpressureStrategy` enum to `RangingConfig`, giving consumers control over how ranging measurements are buffered when the consumer falls behind the platform update rate. Document `kmp-uwb-connector` module, add versioning policy, update 1.0 roadmap.

Closes #36, #37, #38, #39, #40.

## Code

- `BackpressureStrategy` enum: `Latest` (DROP_OLDEST, default), `Buffer` (UNLIMITED), `Drop` (DROP_LATEST)
- `createResultChannel()` factory in `commonMain` — shared by Android and iOS, eliminates duplicated channel construction
- `RangingConfig.backpressureStrategy` field positioned before `sessionKey` (more commonly used)
- Buffer capacity 64 exposed as `internal` constant for test assertions

## Documentation

- README: module table, connector section with error handling, BLE+UWB integration flow, backpressure example
- CONTRIBUTING.md: versioning policy (pre/post-1.0), release process, iOS test instructions
- ROADMAP.md: 1.0 checklist with checkboxes, completed doc items checked
- ARCHITECTURE.md: updated ranging pipeline section
- CHANGELOG.md: Keep a Changelog format entries

## Test plan

- [x] `BackpressureStrategyTest`: default strategy, DSL builder
- [x] `ResultChannelTest`: Latest drops oldest, Buffer keeps all, Drop discards newest
- [x] `RangingConfigTest`: default backpressure is `Latest`
- [x] ktlint clean
- [x] JVM tests pass
- [ ] CI: Android build + test
- [ ] CI: iOS build + test