### PR TITLE
fix: thread safety, error handling, and documentation accuracy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -296,4 +296,4 @@ fake.simulateUnsupported() // state → UNSUPPORTED
 
 ---
 
-*Current as of v0.1.0*
+*Current as of v0.2.0*

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ session.rangingResults.collect { result ->
             println("Elevation: ${result.measurement.elevation}")     // vertical angle
         }
         is RangingResult.PeerLost -> println("Lost: ${result.peer}")
-        is RangingResult.PeerRecovered -> println("Recovered: ${result.peer}")
+        is RangingResult.PeerRecovered -> println("Back: ${result.peer}")  // emitted by FakeRangingSession for testing
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,15 @@ val config = rangingConfig {
 ### Start ranging
 
 ```kotlin
-val session = RangingSession(config)
-val peer = Peer(address = PeerAddress(peerAddressBytes))
+val adapter = UwbAdapter()
+val prepared = adapter.prepareSession(config)
 
-session.start(peer)
+// Exchange params with peer over BLE, NFC, or WiFi
+val localBytes = prepared.localParams.toByteArray()
+// ... send localBytes to peer, receive remoteBytes ...
+val remoteParams = SessionParams(remoteBytes)
+
+val session = prepared.startRanging(remoteParams)
 
 // Observe state
 session.state.collect { state ->
@@ -146,8 +151,6 @@ val fakeSession = FakeRangingSession(
     config = rangingConfig { role = RangingRole.CONTROLLER },
 )
 val peer = Peer(address = PeerAddress(byteArrayOf(0x01, 0x02)))
-
-fakeSession.start(peer)
 
 // Inject a measurement
 fakeSession.emitResult(

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -127,4 +127,4 @@ Features we're tracking but not actively working on. Community interest and use 
 
 ---
 
-*Current as of v0.1.x*
+*Current as of v0.2.0*

--- a/kmp-uwb-connector/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ble/BleConnector.kt
+++ b/kmp-uwb-connector/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ble/BleConnector.kt
@@ -130,6 +130,10 @@ private class ControllerConnector(
             }
 
             return SessionParams(remoteBytes)
+        } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+            throw ConnectorException(
+                ExchangeTimedOut("BLE param exchange timed out within ${config.exchangeTimeout}", cause = e),
+            )
         } catch (e: CancellationException) {
             throw e
         } catch (e: ConnectorException) {

--- a/kmp-uwb-connector/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ble/BleConnector.kt
+++ b/kmp-uwb-connector/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ble/BleConnector.kt
@@ -142,11 +142,7 @@ private class ControllerConnector(
     }
 
     private fun safeDisconnect(peripheral: Peripheral) {
-        try {
-            peripheral.close()
-        } catch (_: Exception) {
-            // cleanup errors must not mask the original
-        }
+        closeQuietly { peripheral.close() }
     }
 }
 
@@ -232,21 +228,18 @@ private class ControleeConnector(
                 TransportFailure("BLE controlee exchange failed: ${e.message}", cause = e),
             )
         } finally {
-            try {
-                advertiser.stopAdvertising()
-            } catch (_: Exception) {
-                // cleanup
-            }
-            try {
-                advertiser.close()
-            } catch (_: Exception) {
-                // cleanup
-            }
-            try {
-                server.close()
-            } catch (_: Exception) {
-                // cleanup
-            }
+            closeQuietly { advertiser.stopAdvertising() }
+            closeQuietly { advertiser.close() }
+            closeQuietly { server.close() }
         }
+    }
+}
+
+/** Runs [block] and swallows any exception — cleanup failures must not mask the original. */
+private inline fun closeQuietly(block: () -> Unit) {
+    try {
+        block()
+    } catch (_: Exception) {
+        // Intentionally swallowed: cleanup failure must not mask the original exception.
     }
 }

--- a/src/androidHostTest/kotlin/com/atruedev/kmpuwb/adapter/KmpUwbInitTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpuwb/adapter/KmpUwbInitTest.kt
@@ -14,22 +14,7 @@ import kotlin.test.assertIs
 class KmpUwbInitTest {
     @BeforeTest
     fun resetKmpUwb() {
-        // Reset the lateinit field via reflection so each test starts clean
-        val field = KmpUwb::class.java.getDeclaredField("appContext")
-        field.isAccessible = true
-        // Use the underlying delegate to clear it — set to a sentinel we can detect
-        // Actually, we need to check if it's initialized first. For lateinit, we use
-        // the Kotlin reflection approach:
-        try {
-            // Force-clear by setting accessible and nulling the backing field
-            val backingField = KmpUwb::class.java.getDeclaredField("appContext")
-            backingField.isAccessible = true
-            // lateinit backing fields are non-null in Kotlin but nullable in JVM bytecode
-            @Suppress("UNCHECKED_CAST")
-            (backingField as java.lang.reflect.Field).set(KmpUwb, null)
-        } catch (_: Exception) {
-            // Field may already be unset
-        }
+        KmpUwb.reset()
     }
 
     @Test

--- a/src/androidHostTest/kotlin/com/atruedev/kmpuwb/session/SessionParamsCodecTest.kt
+++ b/src/androidHostTest/kotlin/com/atruedev/kmpuwb/session/SessionParamsCodecTest.kt
@@ -168,6 +168,35 @@ class SessionParamsCodecTest {
     }
 
     @Test
+    fun decodeRejectsOversizedAddress() {
+        // addressLen = 16, exceeds FiRa max of 8
+        val header = byteArrayOf(0x01, 0x10)
+        val address = ByteArray(16) { (it + 1).toByte() }
+        val trailer = byteArrayOf(0x09, 0x00, 0x00, 0x00, 0x00, 0x01)
+        assertFailsWith<IllegalArgumentException> {
+            SessionParamsCodec.decode(SessionParams(header + address + trailer))
+        }
+    }
+
+    @Test
+    fun decodeRejectsZeroLengthAddress() {
+        val bytes =
+            byteArrayOf(
+                0x01, // version
+                0x00, // addressLen = 0
+                0x09,
+                0x00, // channel, preamble
+                0x00,
+                0x00,
+                0x00,
+                0x01, // sessionId
+            )
+        assertFailsWith<IllegalArgumentException> {
+            SessionParamsCodec.decode(SessionParams(bytes))
+        }
+    }
+
+    @Test
     fun decodedParamsEquality() {
         val a =
             SessionParamsCodec.DecodedParams(

--- a/src/androidMain/kotlin/com/atruedev/kmpuwb/adapter/AndroidUwbAdapter.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpuwb/adapter/AndroidUwbAdapter.kt
@@ -7,6 +7,7 @@ import com.atruedev.kmpuwb.config.RangingConfig
 import com.atruedev.kmpuwb.config.RangingRole
 import com.atruedev.kmpuwb.session.AndroidPreparedSession
 import com.atruedev.kmpuwb.session.PreparedSession
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -36,7 +37,10 @@ internal class AndroidUwbAdapter(
                 supportedChannels = capabilities.supportedChannels.toSet(),
                 backgroundRangingSupported = capabilities.isBackgroundRangingSupported,
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (_: Exception) {
+            // Android UWB SDK (alpha) does not document specific exception types.
             UwbCapabilities.NONE
         }
     }
@@ -61,6 +65,7 @@ internal class AndroidUwbAdapter(
             UwbManager.createInstance(context)
             UwbAdapterState.ON
         } catch (_: Exception) {
+            // Alpha SDK — any createInstance() failure means UWB is unavailable.
             UwbAdapterState.OFF
         }
     }

--- a/src/androidMain/kotlin/com/atruedev/kmpuwb/adapter/KmpUwb.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpuwb/adapter/KmpUwb.kt
@@ -3,24 +3,21 @@ package com.atruedev.kmpuwb.adapter
 import android.content.Context
 
 public object KmpUwb {
-    internal lateinit var appContext: Context
-        private set
+    private var contextHolder: Context? = null
+
+    internal val appContext: Context
+        get() =
+            contextHolder ?: error(
+                "Call KmpUwb.init(context) in your Application.onCreate() before using kmp-uwb",
+            )
 
     public fun init(context: Context) {
-        appContext = context.applicationContext
+        contextHolder = context.applicationContext
     }
 
-    internal fun requireContext(): Context {
-        check(::appContext.isInitialized) {
-            "Call KmpUwb.init(context) in your Application.onCreate() before using kmp-uwb"
-        }
-        return appContext
-    }
+    internal fun requireContext(): Context = appContext
 
-    @Suppress("VisibleForTesting")
     internal fun reset() {
-        val field = KmpUwb::class.java.getDeclaredField("appContext")
-        field.isAccessible = true
-        field.set(this, null)
+        contextHolder = null
     }
 }

--- a/src/androidMain/kotlin/com/atruedev/kmpuwb/session/AndroidPreparedSession.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpuwb/session/AndroidPreparedSession.kt
@@ -83,12 +83,11 @@ internal class AndroidPreparedSession(
             CoroutineScope(
                 SupervisorJob() + Dispatchers.Default.limitedParallelism(1) + CoroutineName("UwbRanging"),
             )
-        val state = MutableStateFlow<RangingState>(RangingState.Starting.Negotiating)
+        val state = MutableStateFlow<RangingState>(RangingState.Starting.Initializing)
         val resultChannel = createResultChannel(backpressureStrategy)
 
         sessionScope.launch {
             try {
-                state.value = RangingState.Starting.Initializing
                 state.value = RangingState.Active.Ranging
 
                 this@AndroidPreparedSession.sessionScope.prepareSession(rangingParameters).collect { platformResult ->
@@ -126,14 +125,22 @@ private class AndroidRangingSession(
     private val _state: MutableStateFlow<RangingState>,
     private val resultChannel: Channel<RangingResult>,
 ) : RangingSession {
+    private val closed = AtomicBoolean(false)
+
     override val state: StateFlow<RangingState> = _state.asStateFlow()
     override val rangingResults = resultChannel.receiveAsFlow()
 
     override fun close() {
-        if (_state.value !is RangingState.Stopped) {
-            _state.value = RangingState.Stopped.ByRequest
+        if (!closed.compareAndSet(false, true)) return
+        val job =
+            scope.launch {
+                if (_state.value !is RangingState.Stopped) {
+                    _state.value = RangingState.Stopped.ByRequest
+                }
+            }
+        job.invokeOnCompletion {
+            resultChannel.close()
+            scope.cancel()
         }
-        resultChannel.close()
-        scope.cancel()
     }
 }

--- a/src/androidMain/kotlin/com/atruedev/kmpuwb/session/SessionParamsCodec.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpuwb/session/SessionParamsCodec.kt
@@ -18,6 +18,7 @@ internal object SessionParamsCodec {
     private const val HEADER_SIZE = 2 // version + addressLen
     private const val CHANNEL_AND_PREAMBLE_SIZE = 2
     private const val SESSION_ID_SIZE = 4
+    private const val MAX_UWB_ADDRESS_SIZE = 8 // FiRa: short (2B) or extended (8B)
 
     data class DecodedParams(
         val address: ByteArray,
@@ -73,6 +74,9 @@ internal object SessionParamsCodec {
         }
 
         val addressLen = buffer.get().toInt() and 0xFF
+        require(addressLen in 1..MAX_UWB_ADDRESS_SIZE) {
+            "Invalid UWB address length: $addressLen (expected 1-$MAX_UWB_ADDRESS_SIZE)"
+        }
         require(buffer.remaining() >= addressLen + CHANNEL_AND_PREAMBLE_SIZE + SESSION_ID_SIZE) {
             "SessionParams truncated: expected ${addressLen + CHANNEL_AND_PREAMBLE_SIZE + SESSION_ID_SIZE} more bytes, got ${buffer.remaining()}"
         }

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/ranging/Angle.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/ranging/Angle.kt
@@ -26,10 +26,16 @@ public value class Angle private constructor(
 
     public companion object {
         /** Create an [Angle] from degrees. */
-        public fun degrees(value: Double): Angle = Angle(value)
+        public fun degrees(value: Double): Angle {
+            require(value.isFinite()) { "Angle must be finite, was $value" }
+            return Angle(value)
+        }
 
         /** Create an [Angle] from radians. */
-        public fun radians(value: Double): Angle = Angle(value * (180.0 / kotlin.math.PI))
+        public fun radians(value: Double): Angle {
+            require(value.isFinite()) { "Angle must be finite, was $value" }
+            return Angle(value * (180.0 / kotlin.math.PI))
+        }
     }
 }
 

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/ranging/Distance.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/ranging/Distance.kt
@@ -28,7 +28,7 @@ public value class Distance private constructor(
     public companion object {
         /** Create a [Distance] from a value in meters. */
         public fun meters(value: Double): Distance {
-            require(value >= 0.0) { "Distance must be non-negative, was $value" }
+            require(value >= 0.0 && value.isFinite()) { "Distance must be non-negative and finite, was $value" }
             return Distance(value.toBits())
         }
 

--- a/src/commonTest/kotlin/com/atruedev/kmpuwb/ranging/AngleTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpuwb/ranging/AngleTest.kt
@@ -4,6 +4,7 @@ import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class AngleTest {
@@ -42,5 +43,26 @@ class AngleTest {
     fun negativeAnglesAreValid() {
         val angle = Angle.degrees(-45.0)
         assertEquals(-45.0, angle.degrees)
+    }
+
+    @Test
+    fun infiniteAngleThrows() {
+        assertFailsWith<IllegalArgumentException> {
+            Angle.degrees(Double.POSITIVE_INFINITY)
+        }
+    }
+
+    @Test
+    fun nanAngleThrows() {
+        assertFailsWith<IllegalArgumentException> {
+            Angle.degrees(Double.NaN)
+        }
+    }
+
+    @Test
+    fun infiniteRadiansThrows() {
+        assertFailsWith<IllegalArgumentException> {
+            Angle.radians(Double.NEGATIVE_INFINITY)
+        }
     }
 }

--- a/src/commonTest/kotlin/com/atruedev/kmpuwb/ranging/DistanceTest.kt
+++ b/src/commonTest/kotlin/com/atruedev/kmpuwb/ranging/DistanceTest.kt
@@ -38,6 +38,20 @@ class DistanceTest {
     }
 
     @Test
+    fun infiniteDistanceThrows() {
+        assertFailsWith<IllegalArgumentException> {
+            Distance.meters(Double.POSITIVE_INFINITY)
+        }
+    }
+
+    @Test
+    fun nanDistanceThrows() {
+        assertFailsWith<IllegalArgumentException> {
+            Distance.meters(Double.NaN)
+        }
+    }
+
+    @Test
     fun zeroDistanceIsValid() {
         val distance = Distance.meters(0.0)
         assertEquals(0.0, distance.meters)

--- a/src/iosMain/kotlin/com/atruedev/kmpuwb/session/IosRangingSession.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpuwb/session/IosRangingSession.kt
@@ -57,6 +57,8 @@ internal class IosRangingSession(
             SupervisorJob() + Dispatchers.Default.limitedParallelism(1) + CoroutineName("UwbRanging"),
         )
 
+    private val closed = kotlin.concurrent.AtomicInt(0)
+
     private val _state = MutableStateFlow<RangingState>(RangingState.Idle.Ready)
     override val state: StateFlow<RangingState> = _state.asStateFlow()
 
@@ -72,11 +74,9 @@ internal class IosRangingSession(
             "Cannot start session in state ${_state.value}"
         }
 
-        _state.value = RangingState.Starting.Negotiating
-
         val session = niSession ?: error("NISession not initialized")
 
-        _state.value = RangingState.Starting.Initializing
+        scope.launch { _state.value = RangingState.Starting.Initializing }.join()
 
         val peerToken = deserializeDiscoveryToken(remoteParams.toByteArray())
         val configuration = NINearbyPeerConfiguration(peerToken)
@@ -96,6 +96,7 @@ internal class IosRangingSession(
     }
 
     override fun close() {
+        if (!closed.compareAndSet(0, 1)) return
         val session = niSession
         niSession = null
         if (session != null) {
@@ -103,11 +104,16 @@ internal class IosRangingSession(
                 session.invalidate()
             }
         }
-        if (_state.value !is RangingState.Stopped) {
-            _state.value = RangingState.Stopped.ByRequest
+        val job =
+            scope.launch {
+                if (_state.value !is RangingState.Stopped) {
+                    _state.value = RangingState.Stopped.ByRequest
+                }
+            }
+        job.invokeOnCompletion {
+            resultChannel.close()
+            scope.cancel()
         }
-        resultChannel.close()
-        scope.cancel()
     }
 
     private inner class SessionDelegate :
@@ -117,6 +123,7 @@ internal class IosRangingSession(
             session: NISession,
             didUpdateNearbyObjects: List<*>,
         ) {
+            if (closed.value != 0) return
             val nearbyObjects = didUpdateNearbyObjects.filterIsInstance<NINearbyObject>()
             for (obj in nearbyObjects) {
                 val rawDistance = obj.distance.toDouble()
@@ -144,6 +151,7 @@ internal class IosRangingSession(
             didRemoveNearbyObjects: List<*>,
             withReason: NINearbyObjectRemovalReason,
         ) {
+            if (closed.value != 0) return
             val removedObjects = didRemoveNearbyObjects.filterIsInstance<NINearbyObject>()
             for (obj in removedObjects) {
                 val peer = Peer(address = tokenCache.resolve(obj.discoveryToken))
@@ -154,10 +162,12 @@ internal class IosRangingSession(
         }
 
         override fun sessionWasSuspended(session: NISession) {
+            if (closed.value != 0) return
             scope.launch { _state.value = RangingState.Active.Suspended }
         }
 
         override fun sessionSuspensionEnded(session: NISession) {
+            if (closed.value != 0) return
             scope.launch { _state.value = RangingState.Active.Ranging }
         }
 
@@ -165,12 +175,15 @@ internal class IosRangingSession(
             session: NISession,
             didInvalidateWithError: platform.Foundation.NSError,
         ) {
+            if (closed.value != 0) return
             val error =
                 SessionLost(
                     message = "NearbyInteraction session invalidated: ${didInvalidateWithError.localizedDescription}",
                 )
-            scope.launch { _state.value = RangingState.Stopped.ByError(error) }
-            resultChannel.close()
+            scope.launch {
+                _state.value = RangingState.Stopped.ByError(error)
+                resultChannel.close()
+            }
         }
 
         override fun session(


### PR DESCRIPTION
## Summary

- Fix race condition in `IosRangingSession.close()` — state mutations now route through the serialized `limitedParallelism(1)` scope with an `AtomicInt` close guard to prevent delegate callbacks from racing with shutdown
- Apply the same single-writer fix to `AndroidRangingSession.close()`
- Fix `CancellationException` swallowing in `AndroidUwbAdapter.capabilities()` that broke structured concurrency
- Replace reflection-based `KmpUwb.reset()` (`getDeclaredField` to null a `lateinit var`) with a nullable field and throwing getter
- Remove unobservable `Starting.Negotiating` state from ranging sessions — negotiation is the connector layer's concern
- Extract `closeQuietly` helper in `BleConnector` to DRY cleanup logic
- Reject `Infinity`/`NaN` in `Distance` and `Angle` factory methods — `Double.POSITIVE_INFINITY` previously passed `Distance` validation
- Bound `SessionParamsCodec` address length to 1-8 bytes per FiRa spec — previously accepted up to 255 bytes from untrusted OOB input
- Classify BLE exchange timeout as `ExchangeTimedOut` instead of `TransportFailure` — `TimeoutCancellationException` was caught by the generic `CancellationException` handler, preventing proper `ConnectorException` wrapping
- Fix README examples referencing non-existent APIs (`RangingSession(config)`, `session.start(peer)`)
- Annotate `PeerRecovered` in README as test-only (no platform emits it yet)
- Update stale version references in ARCHITECTURE.md and ROADMAP.md

## Test plan

- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew testAndroidHostTest` passes (includes new `SessionParamsCodec` bounds tests)
- [x] `./gradlew jvmTest` passes (includes new `Distance`/`Angle` finite validation tests)
- [x] `./gradlew compileKotlinIosSimulatorArm64` compiles
- [ ] CI validates full matrix (Android, iOS, docs)