### PR TITLE
chore: add agent guidelines and typography pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Block Unicode typography characters in staged content.
+#
+# Per-line bypass: append `typo-ok` anywhere on the offending line (matched
+#                  against content only, not file path).
+# Path-level bypass: edit EXCLUDE_PATHS below.
+#
+# Requires git compiled with PCRE2 (default on Apple Git, Homebrew git, and
+# most Linux distros).
+# No `-e`: git grep's exit code is part of normal control flow (1 = no matches).
+set -uo pipefail
+
+files=()
+while IFS= read -r -d '' f; do
+  files+=("$f")
+done < <(git diff --cached --name-only -z --diff-filter=ACM)
+
+[ ${#files[@]} -eq 0 ] && exit 0
+
+# em-dash, en-dash, single curly quotes, double curly quotes, ellipsis, NBSP
+pattern='(*UTF)[\x{2013}\x{2014}\x{2018}\x{2019}\x{201C}\x{201D}\x{2026}\x{00A0}]'
+
+EXCLUDE_PATHS=(
+  ':(glob,exclude)**/testdata/**'
+  ':(glob,exclude)**/*.fixture.*'
+)
+
+out=$(git grep --cached -nP "$pattern" -- "${files[@]}" "${EXCLUDE_PATHS[@]}")
+rc=$?
+case $rc in
+  0) ;;          # matches found; fall through to filter
+  1) exit 0 ;;   # no matches
+  *) echo "pre-commit: git grep failed (exit $rc)" >&2; exit $rc ;;
+esac
+
+# Strip `file:line:` prefix before checking for the pragma so it can't be
+# smuggled via filename or path.
+violations=$(printf '%s\n' "$out" | awk '{
+  s = $0
+  sub(/^[^:]+:[0-9]+:/, "", s)
+  if (s !~ /typo-ok/) print $0
+}')
+
+if [ -n "$violations" ]; then
+  echo "Forbidden typography character (em/en-dash, smart quote, ellipsis, NBSP):" >&2
+  echo "$violations" >&2
+  echo >&2
+  echo "Use ASCII (-, ', \", ...) or append 'typo-ok' to the line to allow." >&2
+  exit 1
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Agent guidelines
+
+Guidance for AI coding agents and humans alike.
+
+## Typography
+
+ASCII only in source, docs, and CI. The pre-commit hook in `.githooks/pre-commit`
+blocks these characters in staged content:
+
+| Char | Codepoint | Use instead |
+|------|-----------|-------------|
+| em-dash      | U+2014 | `-` |
+| en-dash      | U+2013 | `-` |
+| left single  | U+2018 | `'` |
+| right single | U+2019 | `'` |
+| left double  | U+201C | `"` |
+| right double | U+201D | `"` |
+| ellipsis     | U+2026 | `...` |
+| NBSP         | U+00A0 | regular space |
+
+If a violation is genuinely required (regex sample, test fixture, verbatim
+quote from a spec), append `typo-ok` anywhere on that line to suppress.
+For bulk cases, paths matching `**/testdata/**` or `**/*.fixture.*` are
+already excluded; extend `EXCLUDE_PATHS` in `.githooks/pre-commit` if you
+need more.
+
+The hook uses `git grep -P` and requires git compiled with PCRE2. Apple Git,
+Homebrew git, and most Linux distros ship with it; if `git grep -P` fails
+on your build, install one of those.
+
+## Commits and branches
+
+Conventional Commits, strictly. Type prefix on both branch name and commit
+subject. Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`,
+`test`, `build`, `ci`, `chore`, `revert`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Kotlin Multiplatform UWB (Ultra-Wideband) library for Android and iOS.
 
-Part of the **kmp** library family alongside [kmp-ble](https://github.com/gary-quinn/kmp-ble). Use kmp-uwb for centimetre-accurate spatial awareness — device ranging, angle-of-arrival, and peer tracking — with the same shared-code-first philosophy.
+Part of the **kmp** library family alongside [kmp-ble](https://github.com/gary-quinn/kmp-ble). Use kmp-uwb for centimetre-accurate spatial awareness - device ranging, angle-of-arrival, and peer tracking - with the same shared-code-first philosophy.
 
 ## Features
 
@@ -17,8 +17,8 @@ Part of the **kmp** library family alongside [kmp-ble](https://github.com/gary-q
 | **Ranging Sessions** | Start peer-to-peer TWR (Two-Way Ranging) sessions with real-time distance and angle measurements |
 | **Angle of Arrival** | Azimuth and elevation from the device's UWB antenna, when hardware supports it |
 | **Adapter State** | Observe hardware availability and query device capabilities |
-| **Session Lifecycle** | 10-state state machine with exhaustive transitions — no ambiguous states |
-| **Composable Errors** | Sealed interface hierarchy — errors can implement multiple facets (`SessionError + HardwareError`) |
+| **Session Lifecycle** | 10-state state machine with exhaustive transitions - no ambiguous states |
+| **Composable Errors** | Sealed interface hierarchy - errors can implement multiple facets (`SessionError + HardwareError`) |
 | **Test Without Hardware** | `FakeRangingSession` and `FakeUwbAdapter` for full UWB simulation in unit tests |
 | **FiRa Compliant** | Static, Dynamic, and Provisioned STS security modes. Controller/Controlee roles |
 
@@ -26,9 +26,9 @@ Part of the **kmp** library family alongside [kmp-ble](https://github.com/gary-q
 
 | Module | Artifact | Description |
 |--------|----------|-------------|
-| **kmp-uwb** | `com.atruedev:kmp-uwb` | Core UWB library — adapter, sessions, ranging, state machine |
+| **kmp-uwb** | `com.atruedev:kmp-uwb` | Core UWB library - adapter, sessions, ranging, state machine |
 | **kmp-uwb-connector** | `com.atruedev:kmp-uwb-connector` | BLE-based out-of-band parameter exchange using [kmp-ble](https://github.com/gary-quinn/kmp-ble) |
-| **kmp-uwb-testing** | `com.atruedev:kmp-uwb-testing` | Test doubles — `FakeRangingSession`, `FakeUwbAdapter`, `FakePreparedSession` |
+| **kmp-uwb-testing** | `com.atruedev:kmp-uwb-testing` | Test doubles - `FakeRangingSession`, `FakeUwbAdapter`, `FakePreparedSession` |
 
 ## Setup
 
@@ -44,7 +44,7 @@ kotlin {
 }
 ```
 
-The library auto-initializes on Android via [AndroidX Startup](https://developer.android.com/topic/libraries/app-startup) — no manual `init()` call needed. If your app disables auto-initialization, call `KmpUwb.init(context)` manually.
+The library auto-initializes on Android via [AndroidX Startup](https://developer.android.com/topic/libraries/app-startup) - no manual `init()` call needed. If your app disables auto-initialization, call `KmpUwb.init(context)` manually.
 
 ### iOS (Swift Package Manager)
 
@@ -183,7 +183,7 @@ val session = prepared.startRanging(remoteParams, BackpressureStrategy.KeepLates
 
 ## kmp-uwb-connector
 
-The connector module automates BLE-based out-of-band (OOB) parameter exchange — the handshake every UWB session requires before ranging can start.
+The connector module automates BLE-based out-of-band (OOB) parameter exchange - the handshake every UWB session requires before ranging can start.
 
 ```kotlin
 commonMain.dependencies {
@@ -261,16 +261,16 @@ kmp-uwb and kmp-ble are **independent libraries** with no compile-time dependenc
 | **Error model** | Composable sealed interfaces | Composable sealed interfaces |
 | **Testing** | FakePeripheral, FakeScanner | FakeRangingSession, FakeUwbAdapter |
 
-A typical spatial app might use kmp-ble for device discovery and data exchange, then kmp-uwb for precise positioning — but neither requires the other.
+A typical spatial app might use kmp-ble for device discovery and data exchange, then kmp-uwb for precise positioning - but neither requires the other.
 
 ## Architecture
 
-- **State machine:** 10 states with sealed interface hierarchy — exhaustive `when` branches
+- **State machine:** 10 states with sealed interface hierarchy - exhaustive `when` branches
 - **Per-session concurrency:** `limitedParallelism(1)` serialization, no locks
 - **Configurable backpressure:** `BackpressureStrategy` (KeepLatest, Unbounded, KeepOldest) for ranging results
 - **Value classes:** `Distance` and `Angle` are zero-allocation wrappers with unit conversion
-- **Composable errors:** Sealed interfaces — `SessionError`, `RangingError`, `HardwareError`, `SecurityError`
-- **Defensive copies:** `PeerAddress` copies on construction and access — no aliasing bugs
+- **Composable errors:** Sealed interfaces - `SessionError`, `RangingError`, `HardwareError`, `SecurityError`
+- **Defensive copies:** `PeerAddress` copies on construction and access - no aliasing bugs
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for full design documentation.
 
@@ -281,6 +281,18 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full design documentation.
 - iOS 15+ (U1/U2 chip required for UWB)
 - kotlinx-coroutines 1.10+
 
+## Contributing
+
+After cloning, enable the repo's pre-commit hooks once:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+The hook blocks Unicode typography characters (em/en-dash, smart quotes,
+ellipsis, NBSP) in staged content. See [AGENTS.md](AGENTS.md) for the full list
+and the `typo-ok` bypass.
+
 ## License
 
-[Apache 2.0](LICENSE) — Copyright (C) 2026 Gary Quinn
+[Apache 2.0](LICENSE) - Copyright (C) 2026 Gary Quinn


### PR DESCRIPTION
## Summary
- New `.githooks/pre-commit` blocks U+2013, U+2014, U+2018, U+2019, U+201C, U+201D, U+2026, U+00A0 in staged content.
- New `AGENTS.md` codifies the typography rule, the bypass mechanisms, and the strict Conventional Commits policy.
- README gains a one-line `git config core.hooksPath .githooks` setup step plus a Contributing section.
- Mirrors [kmp-ble#156](https://github.com/gary-quinn/kmp-ble/pull/156).

## Hook design
- Scoped to staged ACM files only (`git diff --cached --name-only -z --diff-filter=ACM` -> `git grep --cached`).
- NUL-safe via `read -d ''` loop (works on macOS bash 3.2).
- **Per-line bypass**: append `typo-ok` to the offending line. Matching strips the `file:line:` prefix in awk first, so a filename like `testdata/typo-ok-fixtures.kt` cannot smuggle a bypass.
- **Path-level bypass**: `EXCLUDE_PATHS=(':(glob,exclude)**/testdata/**' ':(glob,exclude)**/*.fixture.*')` for bulk test fixtures.
- **Fail-closed**: explicit case on `git grep` exit code. rc=0 -> matches, rc=1 -> no matches, anything else -> hook errors out instead of silently passing.
- **PCRE2** required (Apple Git, Homebrew git, most Linux distros ship with it). Documented in AGENTS.md.

## Note on README normalization
The existing README contained em-dashes throughout. Since the hook checks the entire staged content of modified files (not just diffs), normalizing them to ASCII was required to dogfood the hook on this very PR. Other docs and source files that still contain Unicode typography are untouched here; they will need cleanup the next time they are modified, or can be normalized in a follow-up.

## Test plan
- [x] Hook passes on this PR's staged content (dogfooded with `core.hooksPath` enabled).
- [x] `git grep -P` is supported on the local Git build.
- [ ] Confirm CI is unaffected (no CI job is added; hook is local-only).