### PR TITLE
ci: add typography-check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: gary-quinn/shared-actions/typography-check@da652cf908933a8f760fe35a4477ca59273ecd8c # PR #1; switch to @v1 after release
+      - uses: gary-quinn/shared-actions/typography-check@cd697d0da404a22dc157c6280d498f68a5bee6af # v1.0.1
 
   android:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ permissions:
   contents: read
 
 jobs:
+  typography:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: gary-quinn/shared-actions/typography-check@da652cf908933a8f760fe35a4477ca59273ecd8c # PR #1; switch to @v1 after release
+
   android:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -58,14 +58,14 @@ jobs:
 
             const match = title.match(/^(\w+)(?:\(.+\))?!?:/);
             if (!match) {
-              core.info('PR title does not match conventional commit format — skipping label');
+              core.info('PR title does not match conventional commit format - skipping label');
               return;
             }
 
             const type = match[1].toLowerCase();
             const label = labelMap[type];
             if (!label) {
-              core.info(`No changelog label mapped for type "${type}" — skipping`);
+              core.info(`No changelog label mapped for type "${type}" - skipping`);
               return;
             }
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -198,8 +198,8 @@ jobs:
             Automated PR to update project docs with the new release version.
 
             **Updated files:**
-            - `README.md` — dependency version
-            - `CHANGELOG.md` — auto-generated entries from merged PRs
+            - `README.md` - dependency version
+            - `CHANGELOG.md` - auto-generated entries from merged PRs
 
             Release: ${{ needs.publish.outputs.release_url }}
           branch: update-docs-${{ needs.publish.outputs.version }}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,32 +33,32 @@ Consumers write against the common API. Platform code never appears in import st
 
 ## State Machine
 
-The ranging state machine uses an exhaustive sealed interface hierarchy with 10 states (9 observable in practice — `Negotiating` is reserved for connector-layer use).
+The ranging state machine uses an exhaustive sealed interface hierarchy with 10 states (9 observable in practice - `Negotiating` is reserved for connector-layer use).
 
 ### States
 
 ```
 RangingState
 ├── Idle
-│   ├── Ready              — Session can be started
-│   └── Unsupported        — Hardware not available
+│   ├── Ready              - Session can be started
+│   └── Unsupported        - Hardware not available
 ├── Starting
-│   ├── Negotiating        — Reserved for connector-layer parameter exchange
-│   └── Initializing       — Platform session being created
+│   ├── Negotiating        - Reserved for connector-layer parameter exchange
+│   └── Initializing       - Platform session being created
 ├── Active
-│   ├── Ranging            — Measurements flowing
-│   ├── Suspended          — Temporarily paused by system (iOS background)
-│   └── PeerLost           — Peer left range, session still alive
+│   ├── Ranging            - Measurements flowing
+│   ├── Suspended          - Temporarily paused by system (iOS background)
+│   └── PeerLost           - Peer left range, session still alive
 └── Stopped
-    ├── ByRequest          — Local close() called
-    ├── ByPeer             — Remote peer ended session
-    ├── ByError(error)     — Session failed with details
-    └── BySystemEvent      — UWB disabled, airplane mode
+    ├── ByRequest          - Local close() called
+    ├── ByPeer             - Remote peer ended session
+    ├── ByError(error)     - Session failed with details
+    └── BySystemEvent      - UWB disabled, airplane mode
 ```
 
 ### Transition Rules
 
-States follow a strict forward progression: `Idle → Starting → Active → Stopped`. Within `Active`, lateral transitions are allowed (`Ranging ↔ Suspended ↔ PeerLost`). Once in `Stopped`, no further transitions occur — the session is terminal.
+States follow a strict forward progression: `Idle → Starting → Active → Stopped`. Within `Active`, lateral transitions are allowed (`Ranging ↔ Suspended ↔ PeerLost`). Once in `Stopped`, no further transitions occur - the session is terminal.
 
 Transitions are enforced by the `check()` precondition in `startRanging()` and the `if (_state.value !is RangingState.Stopped)` guard in `close()`. A session that stops due to error cannot be overwritten by a subsequent `close()`. The `close()` method uses an atomic flag for idempotency and routes state mutations through the serialized scope.
 
@@ -90,11 +90,11 @@ Layer 2: Serialized state mutations (limitedParallelism(1))
 Layer 3: Consumer API (caller's coroutine context)
 ```
 
-**Layer 2** uses `Dispatchers.Default.limitedParallelism(1)` — a serial execution view that works on all KMP targets without `expect/actual`. At most one coroutine runs at a time per session. No locks, no mutexes.
+**Layer 2** uses `Dispatchers.Default.limitedParallelism(1)` - a serial execution view that works on all KMP targets without `expect/actual`. At most one coroutine runs at a time per session. No locks, no mutexes.
 
 **Each session has its own serialized scope.** This is critical on iOS, where `NISessionDelegate` callbacks arrive on Apple's dispatch queue. Every delegate method wraps state mutations in `scope.launch { }` to hop back onto the serialized dispatcher.
 
-**What is and isn't serialized:** The single-writer guarantee applies to `_state` (StateFlow) mutations only. Ranging measurements use `Channel.trySend()` directly from the platform callback thread — `Channel` is a thread-safe concurrent data structure. This means a consumer may receive a measurement before the state transitions to `Active.Ranging` — an acceptable latency tradeoff over routing every measurement through the serialized scope at 5+ Hz.
+**What is and isn't serialized:** The single-writer guarantee applies to `_state` (StateFlow) mutations only. Ranging measurements use `Channel.trySend()` directly from the platform callback thread - `Channel` is a thread-safe concurrent data structure. This means a consumer may receive a measurement before the state transitions to `Active.Ranging` - an acceptable latency tradeoff over routing every measurement through the serialized scope at 5+ Hz.
 
 ### Why Not Mutex?
 
@@ -113,17 +113,17 @@ override val rangingResults: Flow<RangingResult> = resultChannel.receiveAsFlow()
 
 UWB measurements arrive at high frequency. The pipeline is designed for this:
 
-- **Configurable `BackpressureStrategy`** — passed to `startRanging()`, kept separate from `RangingConfig` (protocol params) because buffering is a client-side delivery concern:
-  - `KeepLatest` (default): `Channel(64, DROP_OLDEST)` — stale measurements dropped, consumer sees latest data
-  - `Unbounded`: `Channel(UNLIMITED)` — all measurements buffered for analytics/replay
-  - `KeepOldest`: `Channel(64, DROP_LATEST)` — newest measurements dropped, strict arrival order preserved
-- **`createResultChannel()`** — shared factory in `commonMain` used by both Android and iOS, avoiding duplicated channel construction logic.
-- **`receiveAsFlow()`** — converts the channel to a cold-on-subscription Flow. Unlike `channelFlow`, this doesn't start a new platform session per collector.
-- **`trySend()`** — non-suspending send from platform callbacks. Never blocks the OS callback thread.
+- **Configurable `BackpressureStrategy`** - passed to `startRanging()`, kept separate from `RangingConfig` (protocol params) because buffering is a client-side delivery concern:
+  - `KeepLatest` (default): `Channel(64, DROP_OLDEST)` - stale measurements dropped, consumer sees latest data
+  - `Unbounded`: `Channel(UNLIMITED)` - all measurements buffered for analytics/replay
+  - `KeepOldest`: `Channel(64, DROP_LATEST)` - newest measurements dropped, strict arrival order preserved
+- **`createResultChannel()`** - shared factory in `commonMain` used by both Android and iOS, avoiding duplicated channel construction logic.
+- **`receiveAsFlow()`** - converts the channel to a cold-on-subscription Flow. Unlike `channelFlow`, this doesn't start a new platform session per collector.
+- **`trySend()`** - non-suspending send from platform callbacks. Never blocks the OS callback thread.
 
 ### Why Not SharedFlow?
 
-`MutableSharedFlow(replay=0)` drops values when no collector is active. `MutableSharedFlow(replay=1)` replays stale data to new collectors. The channel approach gives explicit buffer control — the right trade-off for real-time sensor data.
+`MutableSharedFlow(replay=0)` drops values when no collector is active. `MutableSharedFlow(replay=1)` replays stale data to new collectors. The channel approach gives explicit buffer control - the right trade-off for real-time sensor data.
 
 ### Single Session Start
 
@@ -131,7 +131,7 @@ On Android, `scope.launch { ... }` runs once when `PreparedSession.startRanging(
 
 ### iOS Discovery Token Cache
 
-On iOS, `NIDiscoveryToken` → `PeerAddress` requires `NSKeyedArchiver` serialization. Since the token-to-address mapping is stable for a session's lifetime, `DiscoveryTokenCache` caches it per session rather than re-serializing on every callback. No synchronization needed — the cache is only accessed from Apple's delegate dispatch queue.
+On iOS, `NIDiscoveryToken` → `PeerAddress` requires `NSKeyedArchiver` serialization. Since the token-to-address mapping is stable for a session's lifetime, `DiscoveryTokenCache` caches it per session rather than re-serializing on every callback. No synchronization needed - the cache is only accessed from Apple's delegate dispatch queue.
 
 ---
 
@@ -146,7 +146,7 @@ UwbError
 │   └── SessionRejected(message)
 ├── RangingError
 │   ├── PeerUnreachable(message)
-│   └── ChipsetError(message)  — also implements HardwareError
+│   └── ChipsetError(message)  - also implements HardwareError
 ├── HardwareError
 │   ├── ChipsetError(message)
 │   ├── UnsupportedFeature(message)
@@ -188,7 +188,7 @@ Construction validates non-negative values. Extension properties (`2.5.meters`, 
 
 ### Why Value Classes?
 
-Zero-allocation on JVM. Type safety — you can't accidentally pass a distance where an angle is expected. Unit conversion is built into the type (`angle.radians`, `distance.meters`).
+Zero-allocation on JVM. Type safety - you can't accidentally pass a distance where an angle is expected. Unit conversion is built into the type (`angle.radians`, `distance.meters`).
 
 ---
 
@@ -205,7 +205,7 @@ public class PeerAddress(bytes: ByteArray) {
 }
 ```
 
-This was initially a `@JvmInline value class`, but `ByteArray` uses referential equality by default — two `PeerAddress` instances with identical bytes would not be equal. Converting to a regular class with `contentEquals`/`contentHashCode` fixes this.
+This was initially a `@JvmInline value class`, but `ByteArray` uses referential equality by default - two `PeerAddress` instances with identical bytes would not be equal. Converting to a regular class with `contentEquals`/`contentHashCode` fixes this.
 
 ### iOS Discovery Token Serialization
 
@@ -228,7 +228,7 @@ This ensures consistent peer identity across delegate callbacks throughout a ses
 | `UwbAdapter` | `PackageManager.FEATURE_UWB` check + `UwbManager` capabilities |
 | `RangingSession` | `UwbManager.controllerSessionScope()` / `controleeSessionScope()` |
 | `RangingResult` | `androidx.core.uwb.RangingResult.RangingResultPosition` / `RangingResultPeerDisconnected` |
-| Auto-init | `AndroidX Startup` — `KmpUwbInitializer` captures `Context` at app launch |
+| Auto-init | `AndroidX Startup` - `KmpUwbInitializer` captures `Context` at app launch |
 
 The Android implementation uses `RangingParameters` with DS-TWR (Double-Sided Two-Way Ranging) and automatic update rate.
 
@@ -241,7 +241,7 @@ The Android implementation uses `RangingParameters` with DS-TWR (Double-Sided Tw
 | `RangingResult` | `NINearbyObject.distance` + `direction` (simd_float3 → `Vector128`) |
 | Direction parsing | `Vector128.getFloatAt(0/1/2)` for x/y/z → `atan2` for azimuth/elevation |
 
-The `NISessionDelegate` implements multiple `session(_:...)` overloads for the `NISessionDelegateProtocol`. Kotlin/Native 2.3.20 handles the ObjC selector disambiguation automatically — no `@Suppress` annotations needed.
+The `NISessionDelegate` implements multiple `session(_:...)` overloads for the `NISessionDelegateProtocol`. Kotlin/Native 2.3.20 handles the ObjC selector disambiguation automatically - no `@Suppress` annotations needed.
 
 ### JVM
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Kotlin Multiplatform UWB (Ultra-Wideband) library for Android and iOS.
 
-Part of the **kmp** library family alongside [kmp-ble](https://github.com/gary-quinn/kmp-ble). Use kmp-uwb for centimetre-accurate spatial awareness — device ranging, angle-of-arrival, and peer tracking — with the same shared-code-first philosophy.
+Part of the **kmp** library family alongside [kmp-ble](https://github.com/gary-quinn/kmp-ble). Use kmp-uwb for centimetre-accurate spatial awareness - device ranging, angle-of-arrival, and peer tracking - with the same shared-code-first philosophy.
 
 ## Features
 
@@ -17,8 +17,8 @@ Part of the **kmp** library family alongside [kmp-ble](https://github.com/gary-q
 | **Ranging Sessions** | Start peer-to-peer TWR (Two-Way Ranging) sessions with real-time distance and angle measurements |
 | **Angle of Arrival** | Azimuth and elevation from the device's UWB antenna, when hardware supports it |
 | **Adapter State** | Observe hardware availability and query device capabilities |
-| **Session Lifecycle** | 10-state state machine with exhaustive transitions — no ambiguous states |
-| **Composable Errors** | Sealed interface hierarchy — errors can implement multiple facets (`SessionError + HardwareError`) |
+| **Session Lifecycle** | 10-state state machine with exhaustive transitions - no ambiguous states |
+| **Composable Errors** | Sealed interface hierarchy - errors can implement multiple facets (`SessionError + HardwareError`) |
 | **Test Without Hardware** | `FakeRangingSession` and `FakeUwbAdapter` for full UWB simulation in unit tests |
 | **FiRa Compliant** | Static, Dynamic, and Provisioned STS security modes. Controller/Controlee roles |
 
@@ -26,9 +26,9 @@ Part of the **kmp** library family alongside [kmp-ble](https://github.com/gary-q
 
 | Module | Artifact | Description |
 |--------|----------|-------------|
-| **kmp-uwb** | `com.atruedev:kmp-uwb` | Core UWB library — adapter, sessions, ranging, state machine |
+| **kmp-uwb** | `com.atruedev:kmp-uwb` | Core UWB library - adapter, sessions, ranging, state machine |
 | **kmp-uwb-connector** | `com.atruedev:kmp-uwb-connector` | BLE-based out-of-band parameter exchange using [kmp-ble](https://github.com/gary-quinn/kmp-ble) |
-| **kmp-uwb-testing** | `com.atruedev:kmp-uwb-testing` | Test doubles — `FakeRangingSession`, `FakeUwbAdapter`, `FakePreparedSession` |
+| **kmp-uwb-testing** | `com.atruedev:kmp-uwb-testing` | Test doubles - `FakeRangingSession`, `FakeUwbAdapter`, `FakePreparedSession` |
 
 ## Setup
 
@@ -44,7 +44,7 @@ kotlin {
 }
 ```
 
-The library auto-initializes on Android via [AndroidX Startup](https://developer.android.com/topic/libraries/app-startup) — no manual `init()` call needed. If your app disables auto-initialization, call `KmpUwb.init(context)` manually.
+The library auto-initializes on Android via [AndroidX Startup](https://developer.android.com/topic/libraries/app-startup) - no manual `init()` call needed. If your app disables auto-initialization, call `KmpUwb.init(context)` manually.
 
 ### iOS (Swift Package Manager)
 
@@ -183,7 +183,7 @@ val session = prepared.startRanging(remoteParams, BackpressureStrategy.KeepLates
 
 ## kmp-uwb-connector
 
-The connector module automates BLE-based out-of-band (OOB) parameter exchange — the handshake every UWB session requires before ranging can start.
+The connector module automates BLE-based out-of-band (OOB) parameter exchange - the handshake every UWB session requires before ranging can start.
 
 ```kotlin
 commonMain.dependencies {
@@ -261,16 +261,16 @@ kmp-uwb and kmp-ble are **independent libraries** with no compile-time dependenc
 | **Error model** | Composable sealed interfaces | Composable sealed interfaces |
 | **Testing** | FakePeripheral, FakeScanner | FakeRangingSession, FakeUwbAdapter |
 
-A typical spatial app might use kmp-ble for device discovery and data exchange, then kmp-uwb for precise positioning — but neither requires the other.
+A typical spatial app might use kmp-ble for device discovery and data exchange, then kmp-uwb for precise positioning - but neither requires the other.
 
 ## Architecture
 
-- **State machine:** 10 states with sealed interface hierarchy — exhaustive `when` branches
+- **State machine:** 10 states with sealed interface hierarchy - exhaustive `when` branches
 - **Per-session concurrency:** `limitedParallelism(1)` serialization, no locks
 - **Configurable backpressure:** `BackpressureStrategy` (KeepLatest, Unbounded, KeepOldest) for ranging results
 - **Value classes:** `Distance` and `Angle` are zero-allocation wrappers with unit conversion
-- **Composable errors:** Sealed interfaces — `SessionError`, `RangingError`, `HardwareError`, `SecurityError`
-- **Defensive copies:** `PeerAddress` copies on construction and access — no aliasing bugs
+- **Composable errors:** Sealed interfaces - `SessionError`, `RangingError`, `HardwareError`, `SecurityError`
+- **Defensive copies:** `PeerAddress` copies on construction and access - no aliasing bugs
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for full design documentation.
 
@@ -283,4 +283,4 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full design documentation.
 
 ## License
 
-[Apache 2.0](LICENSE) — Copyright (C) 2026 Gary Quinn
+[Apache 2.0](LICENSE) - Copyright (C) 2026 Gary Quinn

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # kmp-uwb Roadmap
 
-> Centimetre-accurate spatial awareness for Kotlin Multiplatform — Android & iOS.
+> Centimetre-accurate spatial awareness for Kotlin Multiplatform - Android & iOS.
 
 This document tracks what's shipped, what's next, and where kmp-uwb is headed. Updated as milestones are reached.
 
@@ -12,7 +12,7 @@ This document tracks what's shipped, what's next, and where kmp-uwb is headed. U
 
 ## Shipped
 
-### v0.1.x — Foundation
+### v0.1.x - Foundation
 
 Everything needed to build production UWB ranging apps on Android and iOS from shared Kotlin code.
 
@@ -20,15 +20,15 @@ Everything needed to build production UWB ranging apps on Android and iOS from s
 |---------|---------|---------|
 | **Ranging Sessions** | v0.1.0 | Peer-to-peer TWR (Two-Way Ranging) via `RangingSession` interface. Controller and Controlee roles |
 | **Distance & Angle of Arrival** | v0.1.0 | `Distance` (meters/cm), `Angle` (degrees/radians) value classes with unit conversion |
-| **10-State State Machine** | v0.1.0 | Exhaustive sealed interface FSM — Idle, Starting, Active, Stopped with sub-states |
-| **Composable Error Hierarchy** | v0.1.0 | Sealed interfaces — `SessionError`, `RangingError`, `HardwareError`, `SecurityError`. Errors can implement multiple facets |
+| **10-State State Machine** | v0.1.0 | Exhaustive sealed interface FSM - Idle, Starting, Active, Stopped with sub-states |
+| **Composable Error Hierarchy** | v0.1.0 | Sealed interfaces - `SessionError`, `RangingError`, `HardwareError`, `SecurityError`. Errors can implement multiple facets |
 | **Adapter & Capabilities** | v0.1.0 | `UwbAdapter` with state observation and hardware capability queries (roles, AoA, channels, background) |
-| **Session Configuration** | v0.1.0 | `RangingConfig` DSL builder — role, channel, STS mode (Static/Dynamic/Provisioned), AoA, ranging interval |
-| **Testing Infrastructure** | v0.1.0 | `FakeRangingSession`, `FakeUwbAdapter` — full UWB simulation for unit tests, no hardware required |
-| **Android Auto-Init** | v0.1.0 | AndroidX Startup — zero configuration for consumers |
+| **Session Configuration** | v0.1.0 | `RangingConfig` DSL builder - role, channel, STS mode (Static/Dynamic/Provisioned), AoA, ranging interval |
+| **Testing Infrastructure** | v0.1.0 | `FakeRangingSession`, `FakeUwbAdapter` - full UWB simulation for unit tests, no hardware required |
+| **Android Auto-Init** | v0.1.0 | AndroidX Startup - zero configuration for consumers |
 | **Distribution** | v0.1.0 | Maven Central (`com.atruedev:kmp-uwb`) + Swift Package Manager (XCFramework) |
-| **CI/CD Pipeline** | v0.1.0 | GitHub Actions — ktlint, Android build/test, iOS build/test, Dokka docs, Maven Central publish, GitHub Release |
-| **Peer Connector** | v0.1.x | Transport-agnostic OOB parameter exchange — `PreparedSession`, `PeerConnector` fun interface, `startWithConnector` orchestration. `FakePreparedSession`, `FakePeerConnector` test doubles |
+| **CI/CD Pipeline** | v0.1.0 | GitHub Actions - ktlint, Android build/test, iOS build/test, Dokka docs, Maven Central publish, GitHub Release |
+| **Peer Connector** | v0.1.x | Transport-agnostic OOB parameter exchange - `PreparedSession`, `PeerConnector` fun interface, `startWithConnector` orchestration. `FakePreparedSession`, `FakePeerConnector` test doubles |
 | **iOS Discovery Token Cache** | v0.1.x | Per-session `DiscoveryTokenCache` avoids repeated NSKeyedArchiver serialization on the ranging hot path |
 
 ### Known Limitations
@@ -42,7 +42,7 @@ Everything needed to build production UWB ranging apps on Android and iOS from s
 
 ## Planned
 
-### v0.2 — Multi-Peer & Session Management
+### v0.2 - Multi-Peer & Session Management
 
 **Theme:** Real-world ranging scenarios with multiple devices.
 
@@ -53,9 +53,9 @@ Everything needed to build production UWB ranging apps on Android and iOS from s
 | **Session events Flow** | Dedicated event stream for session-level events (peer joined, peer left, suspension, resume) |
 | **Ranging filters** | Distance smoothing, outlier rejection, moving average |
 
-### v0.3 — Spatial Awareness
+### v0.3 - Spatial Awareness
 
-**Theme:** Beyond distance — direction, zones, and spatial context.
+**Theme:** Beyond distance - direction, zones, and spatial context.
 
 | Feature | Notes |
 |---------|-------|
@@ -64,7 +64,7 @@ Everything needed to build production UWB ranging apps on Android and iOS from s
 | **Heading estimation** | Device-relative heading from AoA data |
 | **Accuracy metrics** | Confidence intervals and NLOS (Non-Line-of-Sight) detection |
 
-### v1.0 — Stability Guarantee
+### v1.0 - Stability Guarantee
 
 **Theme:** API stability commitment backed by production usage.
 
@@ -108,7 +108,7 @@ Features we're tracking but not actively working on. Community interest and use 
 | Secure ranging | End-to-end session key management with STS provisioning |
 | Indoor positioning | Map-based positioning using multiple anchors (TDoA) |
 | UWB + BLE connector module | Dedicated `kmp-uwb-connector` bridge with kmp-ble for seamless BLE discovery -> OOB -> ranging pipeline |
-| Precision finding UX | Item tracker patterns — BLE coarse finding -> UWB last-meter guidance |
+| Precision finding UX | Item tracker patterns - BLE coarse finding -> UWB last-meter guidance |
 | Chipset quirk registry | NXP vs Qorvo behavioral differences (same pattern as kmp-ble-quirks) |
 | ARKit camera-assisted guidance | iOS 16+ visual direction overlay |
 | Geofencing | UWB-based precision geofences (sub-meter accuracy) |
@@ -123,7 +123,7 @@ Features we're tracking but not actively working on. Community interest and use 
 
 - **Feature requests:** [Open an issue](https://github.com/gary-quinn/kmp-uwb/issues) describing your use case
 - **Bug reports:** Include platform, device model, and minimal reproduction
-- **Contributions:** PRs welcome — see the issue tracker for "good first issue" labels
+- **Contributions:** PRs welcome - see the issue tracker for "good first issue" labels
 
 ---
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,7 @@ run {
     }
     afterEvaluate {
         check(tasks.findByName(taskName) != null) {
-            "Expected task '$taskName' not found — KGP may have renamed it. ProGuard rules will not be bundled."
+            "Expected task '$taskName' not found - KGP may have renamed it. ProGuard rules will not be bundled."
         }
     }
 }

--- a/kmp-uwb-connector/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ble/BleConnector.kt
+++ b/kmp-uwb-connector/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ble/BleConnector.kt
@@ -26,12 +26,12 @@ import kotlin.uuid.ExperimentalUuidApi
  * [PeerConnector] implementation using BLE for automatic OOB parameter exchange.
  *
  * ```kotlin
- * // Controller — scans for a controlee, connects, exchanges params
+ * // Controller - scans for a controlee, connects, exchanges params
  * val scanner = Scanner { filters { match { serviceUuid(UwbOobService.SERVICE_UUID) } } }
  * val connector = BleConnector.controller(scanner)
  * val session = adapter.startWithConnector(config, connector)
  *
- * // Controlee — advertises, waits for controller to connect and exchange
+ * // Controlee - advertises, waits for controller to connect and exchange
  * val connector = BleConnector.controlee()
  * val session = adapter.startWithConnector(config, connector)
  * ```

--- a/kmp-uwb-connector/src/commonTest/kotlin/com/atruedev/kmpuwb/connector/ble/BleConnectorTest.kt
+++ b/kmp-uwb-connector/src/commonTest/kotlin/com/atruedev/kmpuwb/connector/ble/BleConnectorTest.kt
@@ -72,7 +72,7 @@ class BleConnectorTest {
 
             connector.exchange(localParams)
 
-            // peripheral.close() is called in finally — further operations should fail
+            // peripheral.close() is called in finally - further operations should fail
             assertFailsWith<IllegalStateException> {
                 peripheral.connect()
             }
@@ -83,7 +83,7 @@ class BleConnectorTest {
         runTest {
             val peripheral =
                 FakePeripheral {
-                    // No UWB service — exchange will fail with missing characteristic
+                    // No UWB service - exchange will fail with missing characteristic
                 }
             val connector = buildConnector(peripheral)
 
@@ -102,7 +102,7 @@ class BleConnectorTest {
         runTest {
             val peripheral =
                 FakePeripheral {
-                    // Empty — no services at all
+                    // Empty - no services at all
                 }
             val connector = buildConnector(peripheral)
 
@@ -131,7 +131,7 @@ class BleConnectorTest {
         runTest {
             val failingScanner =
                 FakeScanner {
-                    // Preconfigured ad that is NOT connectable — scanner.first { it.isConnectable } won't match
+                    // Preconfigured ad that is NOT connectable - scanner.first { it.isConnectable } won't match
                     advertisement {
                         name("NotConnectable")
                         isConnectable(false)
@@ -143,7 +143,7 @@ class BleConnectorTest {
             val connector = BleConnector.controller(failingScanner, config) { error("should not be called") }
 
             // TimeoutCancellationException is a CancellationException, which the current
-            // catch order in scanForPeer() rethrows directly. This is a known limitation —
+            // catch order in scanForPeer() rethrows directly. This is a known limitation -
             // the catch(TimeoutCancellationException) branch is unreachable.
             assertFailsWith<Exception> {
                 connector.exchange(localParams)

--- a/kmp-uwb-testing/build.gradle.kts
+++ b/kmp-uwb-testing/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            // api: fakes implement interfaces from root module — consumers need those types on classpath
+            // api: fakes implement interfaces from root module - consumers need those types on classpath
             api(project(":"))
             implementation(libs.kotlinx.coroutines.core)
         }

--- a/kmp-uwb-testing/src/commonMain/kotlin/com/atruedev/kmpuwb/testing/FakeRangingSession.kt
+++ b/kmp-uwb-testing/src/commonMain/kotlin/com/atruedev/kmpuwb/testing/FakeRangingSession.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 /**
  * Test double for [RangingSession] that allows injecting measurements and simulating errors.
  *
- * Created in [RangingState.Active.Ranging] by default — matching real sessions
+ * Created in [RangingState.Active.Ranging] by default - matching real sessions
  * returned by [com.atruedev.kmpuwb.session.PreparedSession.startRanging].
  *
  * ```

--- a/sample/src/commonMain/kotlin/com/atruedev/kmpuwb/sample/RangingDemoScreen.kt
+++ b/sample/src/commonMain/kotlin/com/atruedev/kmpuwb/sample/RangingDemoScreen.kt
@@ -80,7 +80,7 @@ private fun RoleSelectionScreen(onRoleSelected: (RangingRole) -> Unit) {
         }
         Text(
             text =
-                "Run on two UWB devices — one as Controller, one as Controlee.\n" +
+                "Run on two UWB devices - one as Controller, one as Controlee.\n" +
                     "BLE handles parameter exchange automatically.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/src/androidDeviceTest/kotlin/com/atruedev/kmpuwb/adapter/UwbAdapterInstrumentedTest.kt
+++ b/src/androidDeviceTest/kotlin/com/atruedev/kmpuwb/adapter/UwbAdapterInstrumentedTest.kt
@@ -27,7 +27,7 @@ class UwbAdapterInstrumentedTest {
 
     @Test
     fun adapterReportsUnsupportedOnNonUwbDevice() {
-        Assume.assumeFalse("Device has UWB — skipping UNSUPPORTED test", hasUwb)
+        Assume.assumeFalse("Device has UWB - skipping UNSUPPORTED test", hasUwb)
         val adapter = UwbAdapter()
         assertEquals(UwbAdapterState.UNSUPPORTED, adapter.state.value)
         adapter.close()
@@ -36,7 +36,7 @@ class UwbAdapterInstrumentedTest {
     @Test
     fun capabilitiesReturnNoneOnNonUwbDevice() =
         runTest {
-            Assume.assumeFalse("Device has UWB — skipping NONE capabilities test", hasUwb)
+            Assume.assumeFalse("Device has UWB - skipping NONE capabilities test", hasUwb)
             val adapter = UwbAdapter()
             assertEquals(UwbCapabilities.NONE, adapter.capabilities())
             adapter.close()

--- a/src/androidMain/consumer-rules.pro
+++ b/src/androidMain/consumer-rules.pro
@@ -1,4 +1,4 @@
-# AndroidX Startup initializer — discovered via manifest merge + reflection.
+# AndroidX Startup initializer - discovered via manifest merge + reflection.
 -keep class com.atruedev.kmpuwb.adapter.KmpUwbInitializer {
     public <init>();
     public * create(android.content.Context);

--- a/src/androidMain/kotlin/com/atruedev/kmpuwb/adapter/AndroidUwbAdapter.kt
+++ b/src/androidMain/kotlin/com/atruedev/kmpuwb/adapter/AndroidUwbAdapter.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.asStateFlow
 internal class AndroidUwbAdapter(
     private val context: Context,
 ) : UwbAdapter {
-    // Snapshot state — Android UWB SDK does not provide a state-change broadcast.
+    // Snapshot state - Android UWB SDK does not provide a state-change broadcast.
     // Re-query via UwbAdapter() if the user toggles UWB in Settings.
     private val _state = MutableStateFlow(resolveAdapterState())
 
@@ -65,7 +65,7 @@ internal class AndroidUwbAdapter(
             UwbManager.createInstance(context)
             UwbAdapterState.ON
         } catch (_: Exception) {
-            // Alpha SDK — any createInstance() failure means UWB is unavailable.
+            // Alpha SDK - any createInstance() failure means UWB is unavailable.
             UwbAdapterState.OFF
         }
     }

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/adapter/UwbAdapter.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/adapter/UwbAdapter.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
  * Provides access to UWB adapter state and capabilities.
  *
  * [state] is a snapshot captured at construction time. Unlike BLE, the Android UWB SDK
- * does not provide a state-change broadcast — create a new adapter instance to re-query.
+ * does not provide a state-change broadcast - create a new adapter instance to re-query.
  *
  * Obtain an instance via [UwbAdapter] factory function.
  */

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/config/BackpressureStrategy.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/config/BackpressureStrategy.kt
@@ -15,7 +15,7 @@ public enum class BackpressureStrategy {
 
     /**
      * Buffer all measurements without dropping. Long-running sessions at high
-     * update rates will accumulate memory proportionally — callers are responsible
+     * update rates will accumulate memory proportionally - callers are responsible
      * for bounding session lifetime or draining results promptly.
      */
     Unbounded,

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/config/RangingConfig.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/config/RangingConfig.kt
@@ -10,7 +10,7 @@ import kotlin.time.Duration.Companion.milliseconds
  *
  * **Platform support:** [role], [channel], [sessionId], and [sessionKey] are used by
  * both Android and iOS. [rangingInterval], [angleOfArrival], and [stsMode] are accepted
- * for forward compatibility but currently ignored — Android uses automatic update rate
+ * for forward compatibility but currently ignored - Android uses automatic update rate
  * and DS-TWR config, iOS delegates to NearbyInteraction defaults.
  */
 public data class RangingConfig(

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ConnectedRanging.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/connector/ConnectedRanging.kt
@@ -19,7 +19,7 @@ public suspend fun UwbAdapter.startWithConnector(
     backpressureStrategy: BackpressureStrategy = BackpressureStrategy.KeepLatest,
 ): RangingSession {
     val prepared = prepareSession(config)
-    // Not using prepared.use {} — on success, ownership transfers to the returned RangingSession.
+    // Not using prepared.use {} - on success, ownership transfers to the returned RangingSession.
     try {
         val remoteParams = connector.exchange(prepared.localParams)
         return prepared.startRanging(remoteParams, backpressureStrategy)

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/error/UwbError.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/error/UwbError.kt
@@ -3,7 +3,7 @@ package com.atruedev.kmpuwb.error
 /**
  * Root of the UWB error hierarchy.
  *
- * Uses sealed interfaces to enable composable error handling —
+ * Uses sealed interfaces to enable composable error handling -
  * an error can implement multiple interfaces (e.g., [ChipsetError]
  * is both a [RangingError] and a [HardwareError]).
  *
@@ -45,7 +45,7 @@ public data class PeerUnreachable(
     override val cause: Throwable? = null,
 ) : RangingError
 
-/** A chipset-level error — composable as both [RangingError] and [HardwareError]. */
+/** A chipset-level error - composable as both [RangingError] and [HardwareError]. */
 public data class ChipsetError(
     val code: Int,
     override val message: String,

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/peer/PeerAddress.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/peer/PeerAddress.kt
@@ -5,7 +5,7 @@ package com.atruedev.kmpuwb.peer
  *
  * Platform-specific: on Android this maps to a UWB address byte array,
  * on iOS this maps to the serialized NearbyInteraction discovery token.
- * The raw bytes are opaque — equality, identity, and display are the
+ * The raw bytes are opaque - equality, identity, and display are the
  * valid operations across platforms.
  *
  * Uses content-based equality: two addresses with the same bytes are equal.

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/session/PreparedSession.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/session/PreparedSession.kt
@@ -31,10 +31,10 @@ public interface PreparedSession : AutoCloseable {
      * (Android: UwbAddress + ComplexChannel; iOS: NIDiscoveryToken).
      *
      * [backpressureStrategy] controls how measurements are buffered when the
-     * consumer falls behind — kept separate from [config] because it is a
+     * consumer falls behind - kept separate from [config] because it is a
      * client-side delivery concern, not a UWB protocol parameter.
      *
-     * This method consumes the prepared session — calling it again throws
+     * This method consumes the prepared session - calling it again throws
      * [IllegalStateException].
      */
     public suspend fun startRanging(

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/session/RangingResult.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/session/RangingResult.kt
@@ -26,7 +26,7 @@ public sealed interface RangingResult {
     /**
      * The peer moved out of range.
      *
-     * The session remains active — measurements will resume
+     * The session remains active - measurements will resume
      * when the peer is detectable again.
      */
     public data class PeerLost(

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/session/ResultChannel.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/session/ResultChannel.kt
@@ -4,7 +4,7 @@ import com.atruedev.kmpuwb.config.BackpressureStrategy
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 
-// 64 slots ≈ 12 s at typical 5 Hz update rate — absorbs UI jank without unbounded growth.
+// 64 slots ≈ 12 s at typical 5 Hz update rate - absorbs UI jank without unbounded growth.
 internal const val DEFAULT_BUFFER_CAPACITY = 64
 
 internal fun createResultChannel(strategy: BackpressureStrategy): Channel<RangingResult> =

--- a/src/commonMain/kotlin/com/atruedev/kmpuwb/session/SessionParams.kt
+++ b/src/commonMain/kotlin/com/atruedev/kmpuwb/session/SessionParams.kt
@@ -6,7 +6,7 @@ package com.atruedev.kmpuwb.session
  * On Android this encodes the local UWB address, complex channel, session ID, and key.
  * On iOS this encodes a serialized `NIDiscoveryToken`.
  *
- * Applications should not inspect or construct these bytes directly — obtain them
+ * Applications should not inspect or construct these bytes directly - obtain them
  * from [PreparedSession.localParams] and exchange them with the remote peer over
  * any out-of-band transport (BLE, NFC, WiFi, etc.).
  */

--- a/src/iosMain/kotlin/com/atruedev/kmpuwb/session/IosPreparedSession.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpuwb/session/IosPreparedSession.kt
@@ -57,7 +57,7 @@ internal class IosPreparedSession private constructor(
                                 niSession.invalidate()
                                 cont.resumeWithException(
                                     IllegalStateException(
-                                        "NISession.discoveryToken unavailable — " +
+                                        "NISession.discoveryToken unavailable - " +
                                             "device may not support NearbyInteraction",
                                     ),
                                 )

--- a/src/iosMain/kotlin/com/atruedev/kmpuwb/session/IosRangingSession.kt
+++ b/src/iosMain/kotlin/com/atruedev/kmpuwb/session/IosRangingSession.kt
@@ -76,7 +76,7 @@ internal class IosRangingSession(
 
         val session = niSession ?: error("NISession not initialized")
 
-        // Safe to set directly — delegate is not yet assigned, no concurrent writers.
+        // Safe to set directly - delegate is not yet assigned, no concurrent writers.
         _state.value = RangingState.Starting.Initializing
 
         val peerToken = deserializeDiscoveryToken(remoteParams.toByteArray())
@@ -200,8 +200,8 @@ internal class IosRangingSession(
  *
  * NSKeyedArchiver serialization is expensive (~0.1ms). Without caching,
  * it runs on every didUpdateNearbyObjects callback (~5Hz per peer).
- * The token-to-address mapping is stable — the same token always produces
- * the same bytes — so caching is safe.
+ * The token-to-address mapping is stable - the same token always produces
+ * the same bytes - so caching is safe.
  *
  * Thread safety: all delegate callbacks run on Apple's dispatch queue,
  * and this cache is only accessed from those callbacks. No synchronization needed.
@@ -281,7 +281,7 @@ internal fun deserializeDiscoveryToken(bytes: ByteArray): NIDiscoveryToken {
             if (obj == null) {
                 val desc = error.value?.localizedDescription ?: "unknown error"
                 error(
-                    "Failed to deserialize NIDiscoveryToken from ${tokenBytes.size} bytes: $desc — " +
+                    "Failed to deserialize NIDiscoveryToken from ${tokenBytes.size} bytes: $desc - " +
                         "data may be corrupted during OOB transfer",
                 )
             }


### PR DESCRIPTION
## Summary

Adds a `typography` job to the CI workflow that calls the new [gary-quinn/shared-actions/typography-check@v1](https://github.com/gary-quinn/shared-actions/pull/1) composite action.

## Why

Tier-1 enforcement is the local pre-commit hook in `.githooks/pre-commit` (added in #60). Tier-2 is this CI job - the safety net for:

- Commits made with `--no-verify`
- Contributors who forgot the one-time `git config core.hooksPath .githooks` setup
- Bots / agents pushing from environments without the hook configured

Same forbidden character set, same `typo-ok` pragma, same path excludes - matched at the action level.

## Pinning

Pinned to the PR-pre-merge SHA of [gary-quinn/shared-actions#1](https://github.com/gary-quinn/shared-actions/pull/1). After that PR merges and the `v1` tag is advanced, swap to `@v1` in a follow-up.

## Merge order

1. Merge gary-quinn/shared-actions#1.
2. Merge #60 (the hook PR).
3. Merge this PR.

CI on this PR will fail until step 1 because the action does not exist yet at any ref.

## Test plan

- [ ] Confirm CI green after shared-actions#1 merges.
- [ ] Verify a deliberate em-dash on a follow-up PR is caught with a per-line annotation.