### PR TITLE
ci: remove broken auto-merge step from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -206,10 +206,4 @@ jobs:
           base: main
           delete-branch: true
 
-      - name: Auto-approve and merge PR
-        if: steps.create-pr.outputs.pull-request-number
-        run: |
-          gh pr review --approve "${{ steps.create-pr.outputs.pull-request-url }}"
-          gh pr merge --squash "${{ steps.create-pr.outputs.pull-request-url }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.AUTO_MERGE_PAT }}
+


### PR DESCRIPTION
## Summary

The \`update-docs\` job fails on every release because the \`AUTO_MERGE_PAT\` secret has expired, causing HTTP 401 at the auto-approve/merge step.

## Changes

- Remove the \`Auto-approve and merge PR\` step from the \`update-docs\` job in \`publish.yml\`
- The PR will still be created automatically; merging will be done manually

## Related

- Same fix applied to kmp-ble: https://github.com/gary-quinn/kmp-ble/pull/575
- Failing run: https://github.com/gary-quinn/kmp-uwb/actions/runs/29684827234/job/88187461007